### PR TITLE
fix: 게시글 조회 오류 개선

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/post/application/serviceImpl/PostServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/post/application/serviceImpl/PostServiceImpl.java
@@ -153,7 +153,7 @@ public class PostServiceImpl implements PostService {
         Integer nextLastLikeCount = hasNext ? dtoList.get(dtoList.size() - 1).getLikeCount() : null;
         Long nextLastViewCount = hasNext ? dtoList.get(dtoList.size() - 1).getViewCount() : null;
 
-        return new PostAllResponseDto(dtoList, new PostAllResponseDto.Pagination(size, nextLastId, hasNext));
+        return new PostAllResponseDto(dtoList, new PostAllResponseDto.Pagination(size, nextLastId, nextLastLikeCount, nextLastViewCount, hasNext));
     }
 
     @Override

--- a/src/main/java/com/kakaotech/ott/ott/post/presentation/controller/PostController.java
+++ b/src/main/java/com/kakaotech/ott/ott/post/presentation/controller/PostController.java
@@ -40,6 +40,7 @@ public class PostController {
         Long userId = (userPrincipal == null) ? null : userPrincipal.getId();
 
         PostAllResponseDto payload = postService.getAllPost(userId, category, sort, size, lastPostId, lastLikeCount, lastViewCount);
+
         return ResponseEntity.ok(ApiResponse.success("게시글 목록 조회 성공", payload));
     }
 

--- a/src/main/java/com/kakaotech/ott/ott/post/presentation/dto/response/PostAllResponseDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/post/presentation/dto/response/PostAllResponseDto.java
@@ -36,7 +36,9 @@ public class PostAllResponseDto {
     @AllArgsConstructor
     public static class Pagination {
         private final int size;
-        private final Long lastPostId;   // 다음 조회의 커서
+        private final Long lastPostId;
+        private final Integer lastLikeCount;
+        private final Long lastViewCount;
         private final boolean hasNext;
     }
 }


### PR DESCRIPTION
## ✏️ PR 내용
### fix: 게시글 조회 오류 개선

### 설명
> 설명: 변경 동기와 내용(무엇을, 어떻게)을 상세히 기술합니다.
- 게시글 조회 중 좋아요, 조회수 순 조회에 대한 중복 데이터 조회 해결

### 테스트 방법
> 설명: 기능이 잘 동작하는지 로컬에서 확인할 수 있는 절차를 기술합니다.
1. 상단에 run 버튼 클릭 후 서버 실행
2. 게시글 조회 페이지에서 조회수순 또는 좋아요순 조회 테스트
