### PR TITLE
fix: 메인 페이지에서 사용자의 이미지 생성 토큰 로직 수정

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/aiImage/presentation/controller/AiImageController.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/presentation/controller/AiImageController.java
@@ -39,7 +39,7 @@ public class AiImageController {
     public ResponseEntity<ApiResponse<CheckAiImageQuotaResponseDto>> checkAiImageQuota(
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
 
-        Long userId = userPrincipal.getId();
+        Long userId = (userPrincipal == null) ? null : userPrincipal.getId();
 
         CheckAiImageQuotaResponseDto responseDto = userAuthService.remainQuota(userId);
         return ResponseEntity.ok(ApiResponse.success("AI 이미지 생성 토큰을 조회합니다.", responseDto));

--- a/src/main/java/com/kakaotech/ott/ott/user/application/serviceImpl/UserAuthServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/user/application/serviceImpl/UserAuthServiceImpl.java
@@ -29,6 +29,9 @@ public class UserAuthServiceImpl implements UserAuthService {
 
     public CheckAiImageQuotaResponseDto remainQuota(Long userId) {
 
+        if (userId == null)
+            throw new CustomException(ErrorCode.AUTH_REQUIRED);
+
         LocalDate today = LocalDate.now();
 
         // 1. 사용자가 존재하지 않으면 예외 발생 (404)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,6 @@ server.forward-headers-strategy=framework
 spring.servlet.multipart.max-file-size=5MB
 spring.servlet.multipart.max-request-size=25MB
 
-server.servlet.session.persistent=false
 spring.profiles.active=${SPRING_PROFILES_ACTIVE:dev}
 
 spring.config.import=optional:classpath:secrets.properties


### PR DESCRIPTION
## ✏️ PR 내용
### fix: 메인 페이지에서 사용자의 이미지 생성 토큰 로직 수정

### 설명
> 설명: 변경 동기와 내용(무엇을, 어떻게)을 상세히 기술합니다.
기존 동작 방싱
- 메인 페이지에서 데스크테리어 생성 버튼을 누르면 사용자의 남은 토큰 횟수를 확인한다.
- 토큰이 남아있으면 이미지 업로드 페이지로 이동하고 그렇지 않으면 "오늘은 더이상 이미지 생성을 할 수 없어요" 모달이 출력된다.
개선 동작 방식
- 메인 페이지에서 데스크테리어 생성 버튼을 누르면 이미지 업로드 페이지로 이동한다.
- 사용자의 남은 토큰 횟수를 화면에 출력한다.
- 남은 토큰 수가 0일 경우, 이미지 업로드를 하더라도 이미지 생성 버튼이 비활성화 된다.


### 테스트 방법
> 설명: 기능이 잘 동작하는지 로컬에서 확인할 수 있는 절차를 기술합니다.

1. IntelliJ 상단에 서버 실행 버튼을 클릭한다.
2. 로그인 후 메인페이지의 데스크 테리어 생성 버튼을 클릭한다.
3. 자신의 토큰을 확인하고 이미지를 업로드 후 버튼 활성 상태를 확인한다.

