### PR TITLE
fix: Service 클래스 @Transactional 추가 및 재설정

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/aiImage/application/serviceImpl/AiImageServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/application/serviceImpl/AiImageServiceImpl.java
@@ -90,7 +90,7 @@ public class AiImageServiceImpl implements AiImageService {
     }
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public AiImageAndProductResponseDto getAiImage(Long imageId, Long userId) {
         AiImage aiImage = aiImageRepository.findById(imageId)
                 .orElseThrow(() -> new CustomException(ErrorCode.AIIMAGE_NOT_FOUND))

--- a/src/main/java/com/kakaotech/ott/ott/comment/application/serviceImpl/CommentServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/comment/application/serviceImpl/CommentServiceImpl.java
@@ -32,6 +32,7 @@ public class CommentServiceImpl implements CommentService {
     private String basicProfile;
 
     @Override
+    @Transactional
     public CommentCreateResponseDto createComment(CommentCreateRequestDto commentCreateRequestDto, Long userId, Long postId) {
 
         Comment comment = Comment.createComment(userId, postId, commentCreateRequestDto.getContent());
@@ -61,6 +62,7 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
+    @Transactional
     public CommentCreateResponseDto updateComment(CommentCreateRequestDto commentCreateRequestDto, Long commentId, Long userId) {
 
         userAuthRepository.findById(userId);
@@ -81,6 +83,7 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public CommentListResponseDto findByPostIdCursor(Long userId, Long postId, Long lastCommentId, int size) {
         // 1) DB에서 댓글을 조회
         List<Comment> commentList = commentRepository.findByPostIdCursor(postId, lastCommentId, size + 1);

--- a/src/main/java/com/kakaotech/ott/ott/product/application/serviceImpl/ProductDomainServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/application/serviceImpl/ProductDomainServiceImpl.java
@@ -22,6 +22,7 @@ import com.kakaotech.ott.ott.user.domain.repository.UserAuthRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +40,7 @@ public class ProductDomainServiceImpl implements ProductDomainService {
     private final ScrapRepository scrapRepository;
 
     @Override
+    @Transactional
     public List<DeskProduct> createdProduct(AiImageAndProductRequestDto aiImageAndProductRequestDto, AiImage aiImage, Long userId) {
         List<DeskProduct> savedDeskProducts = new ArrayList<>();
 

--- a/src/main/java/com/kakaotech/ott/ott/reply/application/serviceImpl/ReplyServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/reply/application/serviceImpl/ReplyServiceImpl.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -32,6 +33,7 @@ public class ReplyServiceImpl implements ReplyService {
     private final UserAuthRepository userAuthRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public ReplyListResponseDto getAllReply(Long userId, Long commentId, Long lastReplyId, int size) {
 
         List<Reply> replyList = replyRepository.findByCommentIdCursor(commentId, lastReplyId, size + 1);
@@ -75,6 +77,7 @@ public class ReplyServiceImpl implements ReplyService {
     }
 
     @Override
+    @Transactional
     public ReplyCreateResponseDto createReply(ReplyCreateRequestDto replyCreateRequestDto, Long userId, Long commentId) {
 
         Reply reply = Reply.createReply(userId, commentId, replyCreateRequestDto.getContent());
@@ -89,6 +92,7 @@ public class ReplyServiceImpl implements ReplyService {
     }
 
     @Override
+    @Transactional
     public ReplyCreateResponseDto updateReply(ReplyCreateRequestDto replyCreateRequestDto, Long replyId, Long userId) {
 
         Reply reply = replyRepository.findById(replyId);
@@ -105,6 +109,7 @@ public class ReplyServiceImpl implements ReplyService {
     }
 
     @Override
+    @Transactional
     public void deleteReply(Long replyId, Long userId){
 
         userAuthRepository.findById(userId);

--- a/src/main/java/com/kakaotech/ott/ott/user/application/serviceImpl/UserAuthServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/user/application/serviceImpl/UserAuthServiceImpl.java
@@ -27,6 +27,7 @@ public class UserAuthServiceImpl implements UserAuthService {
     private final KakaoLogoutServiceImpl kakaoLogoutService;
     private final RefreshTokenRepository refreshTokenRepository;
 
+    @Transactional(readOnly = true)
     public CheckAiImageQuotaResponseDto remainQuota(Long userId) {
 
         if (userId == null)
@@ -47,6 +48,7 @@ public class UserAuthServiceImpl implements UserAuthService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public boolean checkQuota(Long userId) {
 
         LocalDate today = LocalDate.now();

--- a/src/main/java/com/kakaotech/ott/ott/user/application/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/user/application/serviceImpl/UserServiceImpl.java
@@ -57,6 +57,7 @@ public class UserServiceImpl implements UserService {
     private String baseUrl;
 
     @Override
+    @Transactional(readOnly = true)
     public MyInfoResponseDto getMyInfo(Long userId) {
 
         User user = userRepository.findById(userId);
@@ -68,6 +69,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public MyDeskImageResponseDto getMyDeskWithCursor(Long userId, Long lastId, int size, String type) {
 
         User user = userRepository.findById(userId);
@@ -162,6 +164,7 @@ public class UserServiceImpl implements UserService {
 
 
     @Override
+    @Transactional
     public UserInfoUpdateResponseDto updateUserInfo(Long userId, UserInfoUpdateRequestDto userInfoUpdateRequestDto) throws IOException {
 
         User user = userRepository.findById(userId);
@@ -201,6 +204,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional
     public void deleteUser(Long userId) {
 
         User user = userRepository.findById(userId);
@@ -215,6 +219,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional
     public void verifiedCode(Long userId, UserVerifiedRequestDto userVerifiedRequestDto) {
 
         User user = userRepository.findById(userId);
@@ -233,6 +238,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional
     public void recoverUser(Long userId) {
 
         User user = userRepository.findById(userId);


### PR DESCRIPTION
## ✏️ PR 내용
### fix: Service 클래스 @Transactional 추가 및 재설정

### 설명
- Service 클래스의 메서드에서 @Transactional 설정을 추가하거나 재설정한다.
- 읽기 전용 메서드는 readOnly=true를 추가하여 쓰기 작업에 대한 예외 감지를 처리한다.