### PR TITLE
chore: LikeRepository의 삭제 메서드명 변경

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/like/application/serviceImpl/LikeServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/like/application/serviceImpl/LikeServiceImpl.java
@@ -57,7 +57,7 @@ public class LikeServiceImpl implements LikeService {
             throw new CustomException(ErrorCode.LIKE_NOT_FOUND);
         }
 
-        likeRepository.deleteByUserEntityIdAndTypeAndTargetId(userId, likeRequestDto.getTargetId());
+        likeRepository.deleteByUserEntityIdAndTargetId(userId, likeRequestDto.getTargetId());
 
         postRepository.incrementLikeCount(likeRequestDto.getTargetId(), -1L);
     }

--- a/src/main/java/com/kakaotech/ott/ott/like/domain/repository/LikeRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/like/domain/repository/LikeRepository.java
@@ -7,7 +7,7 @@ import java.util.Set;
 
 public interface LikeRepository {
 
-    void deleteByUserEntityIdAndTypeAndTargetId(Long userId, Long postId);
+    void deleteByUserEntityIdAndTargetId(Long userId, Long postId);
 
     Like save(Like like);
 

--- a/src/main/java/com/kakaotech/ott/ott/like/infrastructure/repositoryImpl/LikeRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/like/infrastructure/repositoryImpl/LikeRepositoryImpl.java
@@ -24,7 +24,7 @@ public class LikeRepositoryImpl implements LikeRepository {
 
     @Override
     @Transactional
-    public void deleteByUserEntityIdAndTypeAndTargetId(Long userId, Long postId) {
+    public void deleteByUserEntityIdAndTargetId(Long userId, Long postId) {
         likeJpaRepository.deleteByUserEntityIdAndTargetId(userId, postId);
     }
 

--- a/src/test/java/com/kakaotech/ott/ott/like/application/serviceImpl/LikeServiceImplTest.java
+++ b/src/test/java/com/kakaotech/ott/ott/like/application/serviceImpl/LikeServiceImplTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class LikeServiceImplTest {
+  
+}

--- a/src/test/java/com/kakaotech/ott/ott/like/domain/model/LikeTest.java
+++ b/src/test/java/com/kakaotech/ott/ott/like/domain/model/LikeTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class LikeTest {
+  
+}


### PR DESCRIPTION
### chore: LikeRepository의 삭제 메서드명 변경

### 설명
- LikeRepository의 deleteByUserEntityIdAndTypeAndTargetId -> deleteByUserEntityIdAndTargetId으로 변경
- type값이 매개변수로 넘어가지 않기 때문에 메서드명에서 제거
