### PR TITLE
chore: userJpaRepository의 findById 반환 예외 CustomException으로 변경

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/like/infrastructure/repositoryImpl/LikeRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/like/infrastructure/repositoryImpl/LikeRepositoryImpl.java
@@ -1,12 +1,13 @@
 package com.kakaotech.ott.ott.like.infrastructure.repositoryImpl;
 
+import com.kakaotech.ott.ott.global.exception.CustomException;
+import com.kakaotech.ott.ott.global.exception.ErrorCode;
 import com.kakaotech.ott.ott.like.domain.model.Like;
 import com.kakaotech.ott.ott.like.domain.repository.LikeJpaRepository;
 import com.kakaotech.ott.ott.like.domain.repository.LikeRepository;
 import com.kakaotech.ott.ott.like.infrastructure.entity.LikeEntity;
 import com.kakaotech.ott.ott.user.infrastructure.entity.UserEntity;
 import com.kakaotech.ott.ott.user.domain.repository.UserJpaRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,7 +34,7 @@ public class LikeRepositoryImpl implements LikeRepository {
     public Like save(Like like) {
 
         UserEntity userEntity = userJpaRepository.findById(like.getUserId())
-                .orElseThrow(() -> new EntityNotFoundException("해당 사용자가 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         LikeEntity likeEntity = LikeEntity.from(like, userEntity);
         LikeEntity savedLikeEntity = likeJpaRepository.save(likeEntity);

--- a/src/test/java/com/kakaotech/ott/ott/like/infrastructure/repositoryImpl/LikeRepositoryImplTest.java
+++ b/src/test/java/com/kakaotech/ott/ott/like/infrastructure/repositoryImpl/LikeRepositoryImplTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class LikeRepositoryImplTest {
+  
+}


### PR DESCRIPTION

### chore: userJpaRepository의 findById 반환 예외 CustomException으로 변경

### 설명
- 유저 정보 조회 시 반환되는 예외 CustomException으로 변경