### PR TITLE
fix: UserEntity의 nicknameKakao 컬럼 NotNull -> nullable로 변경

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/user/infrastructure/entity/UserEntity.java
+++ b/src/main/java/com/kakaotech/ott/ott/user/infrastructure/entity/UserEntity.java
@@ -32,7 +32,7 @@ public class UserEntity extends AuditEntity {
     @Column(length = 10)
     private Role role;
 
-    @Column(name = "nickname_kakao", nullable = false, length = 20)
+    @Column(name = "nickname_kakao", length = 20)
     private String nicknameKakao;
 
     @Column(name = "nickname_community", nullable = false, length = 20)


### PR DESCRIPTION
### fix: UserEntity의 nicknameKakao 컬럼 NotNull -> nullable로 변경

### 설명
- 기존 UserEntity에서 nicknameKakao 컬럼은 nullable = false로 설정
- 해당 컬럼은 회원가입 후 카테부 인증 후 설정할 수 있는 컬럼으로 nullable = true로 변경
