### PR TITLE
fix: 로그 경로가 아니라 파일명 기준으로 실행하도록 변경

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -154,7 +154,7 @@ jobs:
               -v /var/log/onthetop/backend:/logs \
               -e SPRING_PROFILES_ACTIVE=${{ env.DEPLOY_ENV }} \
               $IMAGE_NAME:${{ github.sha }} \
-              --logging.file.path=/logs/backend.log \
+              --logging.file.name=/logs/backend.log \
               --spring.config.additional-location=file:/app/secrets.properties
 
             echo " 컨테이너가 8080 포트에서 실행 중입니다."


### PR DESCRIPTION
## ✏️ PR 내용
### 로그 파일 경로 변경

### 설명
docker 실행 시
`--logging.file.path=/logs/backend.log`
와 같이 설정하면 
/logs/backend.log/spring.log 에 로그가 저장됩니다. 그래서 의도한 것 처럼 로그 수집이 불가능합니다.
그래서
`--logging.file.name=/logs/backend.log`
와 같이 변경했습니다.

