### PR TITLE
feat: User, Post에 대한 값 존재 유무에 따른 테스트 코드 추가

### DIFF
--- a/src/test/java/com/kakaotech/ott/ott/like/application/serviceImpl/LikeServiceImplTest.java
+++ b/src/test/java/com/kakaotech/ott/ott/like/application/serviceImpl/LikeServiceImplTest.java
@@ -85,6 +85,52 @@ class LikeServiceImplTest {
         assertEquals("이미 좋아요한 게시글입니다.", exception.getMessage());
     }
 
+    @Test
+    void 게시글에_좋아요시_사용자_정보없음으로_USER_NOT_FOUND_예외발생() {
+
+        // given
+        Long userId = 999L;
+        LikeType type = LikeType.POST;
+        Long targetId = 1L;
+
+        LikeRequestDto likeRequestDto = new LikeRequestDto(type, targetId);
+
+        when(userAuthRepository.findById(userId)).thenThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // when & then
+        CustomException exception = assertThrows(
+                CustomException.class,
+                () -> likeServiceImpl.likePost(userId, likeRequestDto)
+        );
+
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+        assertEquals("해당 사용자가 존재하지 않습니다.", exception.getMessage());
+    }
+
+    @Test
+    void 게시글에_좋아요시_게시글_정보없음으로_POST_NOT_FOUND_예외발생() {
+
+        // given
+        Long userId = 1L;
+        LikeType type = LikeType.POST;
+        Long targetId = 999L;
+
+        LikeRequestDto likeRequestDto = new LikeRequestDto(type, targetId);
+
+        when(userAuthRepository.findById(userId)).thenReturn(mock(User.class));
+        when(postRepository.findById(targetId)).thenThrow(new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        // when & then
+        CustomException exception = assertThrows(
+                CustomException.class,
+                () -> likeServiceImpl.likePost(userId, likeRequestDto)
+        );
+
+        verify(userAuthRepository, times(1)).findById(userId);
+        assertEquals(ErrorCode.POST_NOT_FOUND, exception.getErrorCode());
+        assertEquals("해당 게시글이 존재하지 않습니다.", exception.getMessage());
+    }
+
 
     @Test
     void 좋아요한_게시글_취소시_삭제_및_카운트_감소_메서드_호출() {
@@ -131,5 +177,51 @@ class LikeServiceImplTest {
 
         assertEquals(ErrorCode.LIKE_NOT_FOUND, exception.getErrorCode());
         assertEquals("좋아요하지 않은 게시글입니다.", exception.getMessage());
+    }
+
+    @Test
+    void 게시글_좋아요취소시_사용자없음으로_USER_NOT_FOUND_예외발생() {
+
+        // given
+        Long userId = 999L;
+        LikeType type = LikeType.POST;
+        Long targetId = 1L;
+
+        LikeRequestDto likeRequestDto = new LikeRequestDto(type, targetId);
+
+        when(userAuthRepository.findById(userId)).thenThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // when & then
+        CustomException exception = assertThrows(
+                CustomException.class,
+                () -> likeServiceImpl.unlikePost(userId, likeRequestDto)
+        );
+
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+        assertEquals("해당 사용자가 존재하지 않습니다.", exception.getMessage());
+    }
+
+    @Test
+    void 게시글_좋아요취소시_게시글없음으로_POST_NOT_FOUND_예외발생() {
+
+        // given
+        Long userId = 1L;
+        LikeType type = LikeType.POST;
+        Long targetId = 999L;
+
+        LikeRequestDto likeRequestDto = new LikeRequestDto(type, targetId);
+
+        when(userAuthRepository.findById(userId)).thenReturn(mock(User.class));
+        when(postRepository.findById(targetId)).thenThrow(new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        // when & then
+        CustomException exception = assertThrows(
+                CustomException.class,
+                () -> likeServiceImpl.likePost(userId, likeRequestDto)
+        );
+
+        verify(userAuthRepository, times(1)).findById(userId);
+        assertEquals(ErrorCode.POST_NOT_FOUND, exception.getErrorCode());
+        assertEquals("해당 게시글이 존재하지 않습니다.", exception.getMessage());
     }
 }


### PR DESCRIPTION
### feat: User, Post에 대한 값 존재 유무에 따른 테스트 코드 추가

### 설명
- LikeServiceImplTest.java에서 User, Post에 대한 값 존재하지 않을 경우 예외 처리 되는 테스트 코드 추가
- 좋아요 또는 취소 시 해당 사용자 및 게시글 정보 존재하지 않을 경우 NOT_FOUND 예외 테스트 코드 작성


### 테스트 방법
- LikeServiceImplTest.java에서 'ctrl + F10' 또는 커버리지로 테스트 코드 실행

### 화면 캡처 / 녹화
![image](https://github.com/user-attachments/assets/0b060faf-b35d-4090-ad26-415da2ed2614)
![image](https://github.com/user-attachments/assets/c9affc7f-426a-4495-8b73-498cd2cdb2d4)

