### PR TITLE
fix: 좋아요 취소 시 Post 호출로 게시글 정보 검증 추가

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/like/application/serviceImpl/LikeServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/like/application/serviceImpl/LikeServiceImpl.java
@@ -50,6 +50,8 @@ public class LikeServiceImpl implements LikeService {
 
         User user = userAuthRepository.findById(userId);
 
+        Post post = postRepository.findById(likeRequestDto.getTargetId());
+
         boolean exists = likeRepository.existsByUserIdAndPostId(userId, likeRequestDto.getTargetId());
 
         // 이미 좋아요 상태라면 아무 동작 하지 않음


### PR DESCRIPTION
### fix: 좋아요 취소 시 Post 호출로 게시글 정보 검증 추가

### 설명
- LikeService에서 좋아요 취소 시 해당 게시글에 대한 값 검증 추가