### PR TITLE
feat: 주문 취소 기능 개발(Soft Delete)

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/productOrder/application/service/ProductOrderService.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/application/service/ProductOrderService.java
@@ -12,4 +12,6 @@ public interface ProductOrderService {
     MyProductOrderHistoryListResponseDto getProductOrderHistory(Long userId, Long lastId, int size);
 
     MyProductOrderResponseDto getProductOrder(Long userId, Long orderId);
+
+    void deleteProductOrder(Long userId, Long orderId);
 }

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/application/serviceimpl/ProductOrderServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/application/serviceimpl/ProductOrderServiceImpl.java
@@ -133,5 +133,17 @@ public class ProductOrderServiceImpl implements ProductOrderService {
         return new MyProductOrderResponseDto(orderInfo, productInfo, userInfo, paymentInfo);
     }
 
+    @Override
+    public void deleteProductOrder(Long userId, Long orderId) {
+
+        User user = userRepository.findById(userId);
+
+        ProductOrder productOrder = productOrderRepository.findByIdAndUserId(orderId, userId);
+
+        productOrder.deleteOrder();
+
+        productOrderRepository.update(productOrder, user);
+    }
+
 
 }

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/domain/repository/ProductOrderRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/domain/repository/ProductOrderRepository.java
@@ -8,6 +8,8 @@ public interface ProductOrderRepository {
 
     ProductOrder save(ProductOrder productOrder, User user);
 
+    ProductOrder update(ProductOrder productOrder, User user);
+
     Slice<ProductOrder> findAllByUserId(Long userId, Long lastOrderId, int size);
 
     ProductOrder findByIdAndUserId(Long orderId, Long userId);

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/infrastructure/entity/ProductOrderEntity.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/infrastructure/entity/ProductOrderEntity.java
@@ -73,6 +73,8 @@ public class ProductOrderEntity {
                 .build();
     }
 
-
+    public void setDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
 
 }

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/infrastructure/repositoryImpl/ProductOrderRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/infrastructure/repositoryImpl/ProductOrderRepositoryImpl.java
@@ -30,6 +30,19 @@ public class ProductOrderRepositoryImpl implements ProductOrderRepository {
     }
 
     @Override
+    @Transactional
+    public ProductOrder update(ProductOrder productOrder, User user) {
+
+        ProductOrderEntity beforeProductOrderEntity = productOrderJpaRepository.findByIdAndUserEntity_IdAndDeletedAtIsNull(productOrder.getId(), user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        beforeProductOrderEntity.setDeletedAt(productOrder.getDeletedAt());
+
+        return beforeProductOrderEntity.toDomain();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public Slice<ProductOrder> findAllByUserId(Long userId, Long lastOrderId, int size) {
 
         Slice<ProductOrderEntity> slice = productOrderJpaRepository.findUserAllProductOrders(userId, lastOrderId, PageRequest.of(0, size));
@@ -38,6 +51,7 @@ public class ProductOrderRepositoryImpl implements ProductOrderRepository {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public ProductOrder findByIdAndUserId(Long orderId, Long userId) {
 
         ProductOrderEntity productOrderEntity = productOrderJpaRepository.findByIdAndUserEntity_IdAndDeletedAtIsNull(orderId, userId)

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/presentation/controller/ProductOrderController.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/presentation/controller/ProductOrderController.java
@@ -4,6 +4,7 @@ import com.kakaotech.ott.ott.global.response.ApiResponse;
 import com.kakaotech.ott.ott.productOrder.application.service.ProductOrderService;
 import com.kakaotech.ott.ott.productOrder.presentation.dto.request.ProductOrderRequestDto;
 import com.kakaotech.ott.ott.productOrder.presentation.dto.response.MyProductOrderHistoryListResponseDto;
+import com.kakaotech.ott.ott.productOrder.presentation.dto.response.MyProductOrderHistoryResponseDto;
 import com.kakaotech.ott.ott.productOrder.presentation.dto.response.MyProductOrderResponseDto;
 import com.kakaotech.ott.ott.productOrder.presentation.dto.response.ProductOrderResponseDto;
 import com.kakaotech.ott.ott.user.domain.model.UserPrincipal;
@@ -34,7 +35,7 @@ public class ProductOrderController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse> getOrderHistory(
+    public ResponseEntity<ApiResponse<MyProductOrderHistoryListResponseDto>> getOrderHistory(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @RequestParam(required = false) Long lastOrderId,
             @RequestParam(defaultValue = "5") int size) {
@@ -42,11 +43,11 @@ public class ProductOrderController {
         Long userId = userPrincipal.getId();
 
         MyProductOrderHistoryListResponseDto myProductOrderHistoryListResponseDto = productOrderService.getProductOrderHistory(userId, lastOrderId, size);
-        return ResponseEntity.ok(ApiResponse.success("주문 내역 조회 성공", myProductOrderHistoryListResponseDto));
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("주문 내역 조회 성공", myProductOrderHistoryListResponseDto));
     }
 
     @GetMapping("/{orderId}")
-    public ResponseEntity<ApiResponse> getOrder(
+    public ResponseEntity<ApiResponse<MyProductOrderResponseDto>> getOrder(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long orderId) {
 
@@ -54,7 +55,19 @@ public class ProductOrderController {
 
         MyProductOrderResponseDto myProductOrderResponseDto = productOrderService.getProductOrder(userId, orderId);
 
-        return ResponseEntity.ok(ApiResponse.success("주문 정보 조회 성공", myProductOrderResponseDto));
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("주문 정보 조회 성공", myProductOrderResponseDto));
+    }
+
+    @DeleteMapping("/{orderId}")
+    public ResponseEntity<ApiResponse> deleteOrder(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long orderId) {
+
+        Long userId = userPrincipal.getId();
+
+        productOrderService.deleteProductOrder(userId, orderId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("주문 취소 성공", null));
     }
 
 }


### PR DESCRIPTION
### feat: 주문 취소 기능 개발(Soft Delete)

### 설명
- 주문 취소 기능 개발
- Soft delete 적용
- ProductOrder의 deleteAt null -> now() 적용

### 테스트 방법
1. IDE 서버 실행  
2. Postman에서 `DELETE /api/v1/orders/{orderId}` 호출  
3. 'POST /api/v1/orders/{orderId}' 호출하여 조회되는지 확인
