### PR TITLE
feat: 주문 구매 확정 기능 개발(사용자 직접 입력, 자동 구매 확정)

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/global/exception/ErrorCode.java
+++ b/src/main/java/com/kakaotech/ott/ott/global/exception/ErrorCode.java
@@ -57,7 +57,7 @@ public enum ErrorCode {
 
     NOT_ORDERED_STATE(HttpStatus.BAD_REQUEST, "주문 대기 상태가 아닙니다."),
     NOT_PAID_STATE(HttpStatus.BAD_REQUEST, "결제 완료 상태가 아닙니다."),
-    NOT_DELIVERABLE_STATE(HttpStatus.BAD_REQUEST, "배송 가능한 상태가 아닙니다."),
+    NOT_DELIVERED_STATE(HttpStatus.BAD_REQUEST, "배송 완료된 상태가 아닙니다."),
 
     ALREADY_ORDERED(HttpStatus.BAD_REQUEST, "이미 주문된 상태입니다."),
     ALREADY_PAID(HttpStatus.BAD_REQUEST, "이미 결제된 주문입니다."),

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/application/component/OrderConfirmBatchJob.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/application/component/OrderConfirmBatchJob.java
@@ -1,0 +1,25 @@
+package com.kakaotech.ott.ott.productOrder.application.component;
+
+import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrder;
+import com.kakaotech.ott.ott.productOrder.domain.repository.ProductOrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class OrderConfirmBatchJob {
+    private final ProductOrderRepository productOrderRepository;
+
+    @Scheduled(cron = "0 0 0 * * ?") // 매일 새벽 3시
+    public void confirmOrders() {
+        List<ProductOrder> ordersToConfirm = productOrderRepository.findOrdersToAutoConfirm(LocalDateTime.now());
+        for (ProductOrder order : ordersToConfirm) {
+            order.confirm();
+            productOrderRepository.confirmProductOrder(order);
+        }
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/application/service/ProductOrderService.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/application/service/ProductOrderService.java
@@ -14,4 +14,6 @@ public interface ProductOrderService {
     MyProductOrderResponseDto getProductOrder(Long userId, Long orderId);
 
     void deleteProductOrder(Long userId, Long orderId);
+
+    void confirmProductOrder(Long userId, Long orderId);
 }

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/application/serviceimpl/ProductOrderServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/application/serviceimpl/ProductOrderServiceImpl.java
@@ -142,7 +142,19 @@ public class ProductOrderServiceImpl implements ProductOrderService {
 
         productOrder.deleteOrder();
 
-        productOrderRepository.update(productOrder, user);
+        productOrderRepository.deleteProductOrder(productOrder, user);
+    }
+
+    @Override
+    public void confirmProductOrder(Long userId, Long orderId) {
+
+        User user = userRepository.findById(userId);
+
+        ProductOrder productOrder = productOrderRepository.findByIdAndUserId(orderId, userId);
+        productOrder.confirm();
+
+        productOrderRepository.confirmProductOrder(productOrder, user);
+
     }
 
 

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/domain/model/ProductOrder.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/domain/model/ProductOrder.java
@@ -26,6 +26,12 @@ public class ProductOrder {
 
     private LocalDateTime orderedAt;
 
+    private LocalDateTime deliveredAt;
+
+    private LocalDateTime confirmedAt;
+
+    private LocalDateTime canceledAt;
+
     private LocalDateTime deletedAt;
 
     private static final ULID ulid = new ULID();
@@ -50,10 +56,11 @@ public class ProductOrder {
     }
 
     public void confirm() {
-        if (this.status != ProductOrderStaus.DELIVERED) throw new CustomException(ErrorCode.NOT_DELIVERABLE_STATE);
+        if (this.status != ProductOrderStaus.DELIVERED) throw new CustomException(ErrorCode.NOT_DELIVERED_STATE);
 
         if (this.status == ProductOrderStaus.CONFIRMED) throw new CustomException(ErrorCode.ALREADY_CONFIRMED);
 
+        this.confirmedAt = LocalDateTime.now();
         this.status = ProductOrderStaus.CONFIRMED;
     }
 
@@ -62,8 +69,21 @@ public class ProductOrder {
 
         if (this.status == ProductOrderStaus.DELIVERED) throw new CustomException(ErrorCode.ALREADY_DELIVERED);
 
+        this.deletedAt = LocalDateTime.now();
         this.status = ProductOrderStaus.DELIVERED;
     }
+
+    public void cancel() {
+        if (this.status != ProductOrderStaus.PAID) throw new CustomException(ErrorCode.NOT_PAID_STATE);
+
+        if (this.status == ProductOrderStaus.DELIVERED) throw new CustomException(ErrorCode.ALREADY_DELIVERED);
+
+        if (this.status == ProductOrderStaus.CONFIRMED) throw new CustomException(ErrorCode.ALREADY_CONFIRMED);
+
+        this.canceledAt = LocalDateTime.now();
+        this.status = ProductOrderStaus.CANCELED;
+    }
+
 
     public void deleteOrder() {
         if(this.deletedAt != null) throw new CustomException(ErrorCode.ALREADY_DELETED);

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/domain/repository/ProductOrderJpaRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/domain/repository/ProductOrderJpaRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface ProductOrderJpaRepository extends JpaRepository<ProductOrderEntity, Long> {
@@ -30,4 +32,11 @@ public interface ProductOrderJpaRepository extends JpaRepository<ProductOrderEnt
 
     Optional<ProductOrderEntity> findByIdAndUserEntity_IdAndDeletedAtIsNull(Long orderId, Long userId);
 
+    Optional<ProductOrderEntity> findByIdAndDeletedAtIsNull(Long orderId);
+
+    @Query("SELECT o FROM ProductOrderEntity o " +
+            "WHERE o.orderedAt <= :now " +
+            "AND o.status <> 'CONFIRMED' " +
+            "AND o.deletedAt IS NULL")
+    List<ProductOrderEntity> findOrdersToAutoConfirm(@Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/domain/repository/ProductOrderRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/domain/repository/ProductOrderRepository.java
@@ -4,13 +4,22 @@ import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrder;
 import com.kakaotech.ott.ott.user.domain.model.User;
 import org.springframework.data.domain.Slice;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface ProductOrderRepository {
 
     ProductOrder save(ProductOrder productOrder, User user);
 
-    ProductOrder update(ProductOrder productOrder, User user);
+    void deleteProductOrder(ProductOrder productOrder, User user);
+
+    void confirmProductOrder(ProductOrder productOrder, User user);
+
+    void confirmProductOrder(ProductOrder productOrder);
 
     Slice<ProductOrder> findAllByUserId(Long userId, Long lastOrderId, int size);
 
     ProductOrder findByIdAndUserId(Long orderId, Long userId);
+
+    List<ProductOrder> findOrdersToAutoConfirm(LocalDateTime now);
 }

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/infrastructure/entity/ProductOrderEntity.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/infrastructure/entity/ProductOrderEntity.java
@@ -44,6 +44,15 @@ public class ProductOrderEntity {
     @Column(name = "ordered_at", nullable = false, updatable = false)
     private LocalDateTime orderedAt;
 
+    @Column(name = "delivered_at")
+    private LocalDateTime deliveredAt;
+
+    @Column(name = "confirmed_at")
+    private LocalDateTime confirmedAt;
+
+    @Column(name = "canceled_at")
+    private LocalDateTime canceledAt;
+
     @Column(name = "deleted_at", nullable = false)
     private LocalDateTime deletedAt;
 
@@ -57,6 +66,9 @@ public class ProductOrderEntity {
                 .subtotalAmount(this.subtotalAmount)
                 .discountAmount(this.discountAmount)
                 .orderedAt(this.orderedAt)
+                .deliveredAt(this.deliveredAt)
+                .confirmedAt(this.confirmedAt)
+                .canceledAt(this.canceledAt)
                 .deletedAt(this.deletedAt)
                 .build();
     }
@@ -69,12 +81,31 @@ public class ProductOrderEntity {
                 .status(productOrder.getStatus())
                 .subtotalAmount(productOrder.getSubtotalAmount())
                 .discountAmount(productOrder.getDiscountAmount())
+                .deliveredAt(productOrder.getDeliveredAt())
+                .confirmedAt(productOrder.getConfirmedAt())
+                .canceledAt(productOrder.getCanceledAt())
                 .deletedAt(productOrder.getDeletedAt())
                 .build();
     }
 
     public void setDeletedAt(LocalDateTime deletedAt) {
         this.deletedAt = deletedAt;
+    }
+
+    public void setStatus(ProductOrderStaus productOrderStaus) {
+        this.status = productOrderStaus;
+    }
+
+    public void setDeliveredAt(LocalDateTime deliveredAt) {
+        this.deliveredAt = deliveredAt;
+    }
+
+    public void setConfirmedAt(LocalDateTime confirmedAt) {
+        this.confirmedAt = confirmedAt;
+    }
+
+    public void setCanceledAt(LocalDateTime canceledAt) {
+        this.canceledAt = canceledAt;
     }
 
 }

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/infrastructure/repositoryImpl/ProductOrderRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/infrastructure/repositoryImpl/ProductOrderRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.kakaotech.ott.ott.productOrder.infrastructure.repositoryImpl;
 import com.kakaotech.ott.ott.global.exception.CustomException;
 import com.kakaotech.ott.ott.global.exception.ErrorCode;
 import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrder;
+import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrderStaus;
 import com.kakaotech.ott.ott.productOrder.domain.repository.ProductOrderJpaRepository;
 import com.kakaotech.ott.ott.productOrder.domain.repository.ProductOrderRepository;
 import com.kakaotech.ott.ott.productOrder.infrastructure.entity.ProductOrderEntity;
@@ -13,6 +14,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -31,14 +35,35 @@ public class ProductOrderRepositoryImpl implements ProductOrderRepository {
 
     @Override
     @Transactional
-    public ProductOrder update(ProductOrder productOrder, User user) {
+    public void deleteProductOrder(ProductOrder productOrder, User user) {
 
         ProductOrderEntity beforeProductOrderEntity = productOrderJpaRepository.findByIdAndUserEntity_IdAndDeletedAtIsNull(productOrder.getId(), user.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
+        beforeProductOrderEntity.setStatus(productOrder.getStatus());
         beforeProductOrderEntity.setDeletedAt(productOrder.getDeletedAt());
+    }
 
-        return beforeProductOrderEntity.toDomain();
+    @Override
+    @Transactional
+    public void confirmProductOrder(ProductOrder productOrder, User user) {
+
+        ProductOrderEntity beforeProductOrderEntity = productOrderJpaRepository.findByIdAndUserEntity_IdAndDeletedAtIsNull(productOrder.getId(), user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        beforeProductOrderEntity.setConfirmedAt(productOrder.getConfirmedAt());
+        beforeProductOrderEntity.setStatus(productOrder.getStatus());
+    }
+
+    @Override
+    @Transactional
+    public void confirmProductOrder(ProductOrder productOrder) {
+
+        ProductOrderEntity beforeProductOrderEntity = productOrderJpaRepository.findByIdAndDeletedAtIsNull(productOrder.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        beforeProductOrderEntity.setConfirmedAt(productOrder.getConfirmedAt());
+        beforeProductOrderEntity.setStatus(ProductOrderStaus.CONFIRMED);
     }
 
     @Override
@@ -58,5 +83,15 @@ public class ProductOrderRepositoryImpl implements ProductOrderRepository {
                 .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
         return productOrderEntity.toDomain();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ProductOrder> findOrdersToAutoConfirm(LocalDateTime now) {
+
+        return productOrderJpaRepository.findOrdersToAutoConfirm(now)
+                .stream()
+                .map(ProductOrderEntity::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/presentation/controller/ProductOrderController.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/presentation/controller/ProductOrderController.java
@@ -70,4 +70,16 @@ public class ProductOrderController {
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("주문 취소 성공", null));
     }
 
+    @PostMapping("/{orderId}/confirm")
+    public ResponseEntity<ApiResponse> confirmOrder(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long orderId) {
+
+        Long userId = userPrincipal.getId();
+
+        productOrderService.confirmProductOrder(userId, orderId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("구매 확정 완료", orderId));
+    }
+
 }


### PR DESCRIPTION
### feat: 주문 구매 확정 기능 개발(사용자 직접 입력, 자동 구매 확정)

### 설명
- 주문 구매 확정 기능 개발
- 사용자 직접 입력, 설정 기간 후 자동 처리(배치)
- 매일 자정 자동 배치 처리 작동

### 테스트 방법
1. IDE 서버 실행  
2. Postman에서 `POST /api/v1/orders/{orderId}/confirm` 호출  
3. 'DELIVERED' 상태에서만 주문 확정이 되는지 확인
4. 매일 자정 자동 배치 처리 되는지 확인
