### PR TITLE
feat: 주문 확정 dto 추가

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/productOrder/application/service/ProductOrderService.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/application/service/ProductOrderService.java
@@ -3,6 +3,7 @@ package com.kakaotech.ott.ott.productOrder.application.service;
 import com.kakaotech.ott.ott.productOrder.presentation.dto.request.ProductOrderRequestDto;
 import com.kakaotech.ott.ott.productOrder.presentation.dto.response.MyProductOrderHistoryListResponseDto;
 import com.kakaotech.ott.ott.productOrder.presentation.dto.response.MyProductOrderResponseDto;
+import com.kakaotech.ott.ott.productOrder.presentation.dto.response.ProductOrderConfirmResponseDto;
 import com.kakaotech.ott.ott.productOrder.presentation.dto.response.ProductOrderResponseDto;
 
 public interface ProductOrderService {
@@ -15,5 +16,5 @@ public interface ProductOrderService {
 
     void deleteProductOrder(Long userId, Long orderId);
 
-    void confirmProductOrder(Long userId, Long orderId);
+    ProductOrderConfirmResponseDto confirmProductOrder(Long userId, Long orderId);
 }

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/application/serviceimpl/ProductOrderServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/application/serviceimpl/ProductOrderServiceImpl.java
@@ -3,14 +3,11 @@ package com.kakaotech.ott.ott.productOrder.application.serviceimpl;
 import com.kakaotech.ott.ott.orderItem.domain.model.OrderItemStatus;
 import com.kakaotech.ott.ott.productOrder.application.service.ProductOrderService;
 import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrder;
-import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrderStaus;
+import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrderStatus;
 import com.kakaotech.ott.ott.productOrder.domain.repository.ProductOrderRepository;
 import com.kakaotech.ott.ott.productOrder.presentation.dto.request.ProductOrderRequestDto;
 import com.kakaotech.ott.ott.productOrder.presentation.dto.request.ServiceProductDto;
-import com.kakaotech.ott.ott.productOrder.presentation.dto.response.MyProductOrderHistoryResponseDto;
-import com.kakaotech.ott.ott.productOrder.presentation.dto.response.MyProductOrderHistoryListResponseDto;
-import com.kakaotech.ott.ott.productOrder.presentation.dto.response.MyProductOrderResponseDto;
-import com.kakaotech.ott.ott.productOrder.presentation.dto.response.ProductOrderResponseDto;
+import com.kakaotech.ott.ott.productOrder.presentation.dto.response.*;
 import com.kakaotech.ott.ott.orderItem.domain.model.OrderItem;
 import com.kakaotech.ott.ott.orderItem.domain.repository.OrderItemRepository;
 import com.kakaotech.ott.ott.user.domain.model.User;
@@ -69,7 +66,7 @@ public class ProductOrderServiceImpl implements ProductOrderService {
                 savedProductOrder.getId(),
                 productOrderRequestDto.getProduct(),
                 totalAmount,
-                ProductOrderStaus.ORDERED,
+                ProductOrderStatus.ORDERED,
                 savedProductOrder.getOrderedAt());
     }
 
@@ -146,15 +143,16 @@ public class ProductOrderServiceImpl implements ProductOrderService {
     }
 
     @Override
-    public void confirmProductOrder(Long userId, Long orderId) {
+    public ProductOrderConfirmResponseDto confirmProductOrder(Long userId, Long orderId) {
 
         User user = userRepository.findById(userId);
 
         ProductOrder productOrder = productOrderRepository.findByIdAndUserId(orderId, userId);
         productOrder.confirm();
 
-        productOrderRepository.confirmProductOrder(productOrder, user);
+        ProductOrder confirmedProductOrder = productOrderRepository.confirmProductOrder(productOrder, user);
 
+        return new ProductOrderConfirmResponseDto(productOrder.getId(), productOrder.getStatus());
     }
 
 

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/domain/model/ProductOrder.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/domain/model/ProductOrder.java
@@ -18,7 +18,7 @@ public class ProductOrder {
 
     private String orderNumber;
 
-    private ProductOrderStaus status;
+    private ProductOrderStatus status;
 
     private int subtotalAmount;
 
@@ -41,47 +41,47 @@ public class ProductOrder {
         return ProductOrder.builder()
                 .userId(userId)
                 .orderNumber(ulid.nextULID())
-                .status(ProductOrderStaus.ORDERED)
+                .status(ProductOrderStatus.ORDERED)
                 .subtotalAmount(subtotalAmount)
                 .discountAmount(discountAmount)
                 .build();
     }
 
     public void pay() {
-        if (this.status != ProductOrderStaus.ORDERED) throw new CustomException(ErrorCode.NOT_ORDERED_STATE);
+        if (this.status != ProductOrderStatus.ORDERED) throw new CustomException(ErrorCode.NOT_ORDERED_STATE);
 
-        if (this.status == ProductOrderStaus.PAID) throw new CustomException(ErrorCode.ALREADY_PAID);
+        if (this.status == ProductOrderStatus.PAID) throw new CustomException(ErrorCode.ALREADY_PAID);
 
-        this.status = ProductOrderStaus.PAID;
+        this.status = ProductOrderStatus.PAID;
     }
 
     public void confirm() {
-        if (this.status != ProductOrderStaus.DELIVERED) throw new CustomException(ErrorCode.NOT_DELIVERED_STATE);
+        if (this.status != ProductOrderStatus.DELIVERED) throw new CustomException(ErrorCode.NOT_DELIVERED_STATE);
 
-        if (this.status == ProductOrderStaus.CONFIRMED) throw new CustomException(ErrorCode.ALREADY_CONFIRMED);
+        if (this.status == ProductOrderStatus.CONFIRMED) throw new CustomException(ErrorCode.ALREADY_CONFIRMED);
 
         this.confirmedAt = LocalDateTime.now();
-        this.status = ProductOrderStaus.CONFIRMED;
+        this.status = ProductOrderStatus.CONFIRMED;
     }
 
     public void deliver() {
-        if (this.status != ProductOrderStaus.PAID) throw new CustomException(ErrorCode.NOT_PAID_STATE);
+        if (this.status != ProductOrderStatus.PAID) throw new CustomException(ErrorCode.NOT_PAID_STATE);
 
-        if (this.status == ProductOrderStaus.DELIVERED) throw new CustomException(ErrorCode.ALREADY_DELIVERED);
+        if (this.status == ProductOrderStatus.DELIVERED) throw new CustomException(ErrorCode.ALREADY_DELIVERED);
 
         this.deletedAt = LocalDateTime.now();
-        this.status = ProductOrderStaus.DELIVERED;
+        this.status = ProductOrderStatus.DELIVERED;
     }
 
     public void cancel() {
-        if (this.status != ProductOrderStaus.PAID) throw new CustomException(ErrorCode.NOT_PAID_STATE);
+        if (this.status != ProductOrderStatus.PAID) throw new CustomException(ErrorCode.NOT_PAID_STATE);
 
-        if (this.status == ProductOrderStaus.DELIVERED) throw new CustomException(ErrorCode.ALREADY_DELIVERED);
+        if (this.status == ProductOrderStatus.DELIVERED) throw new CustomException(ErrorCode.ALREADY_DELIVERED);
 
-        if (this.status == ProductOrderStaus.CONFIRMED) throw new CustomException(ErrorCode.ALREADY_CONFIRMED);
+        if (this.status == ProductOrderStatus.CONFIRMED) throw new CustomException(ErrorCode.ALREADY_CONFIRMED);
 
         this.canceledAt = LocalDateTime.now();
-        this.status = ProductOrderStaus.CANCELED;
+        this.status = ProductOrderStatus.CANCELED;
     }
 
 

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/domain/model/ProductOrderStatus.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/domain/model/ProductOrderStatus.java
@@ -1,6 +1,6 @@
 package com.kakaotech.ott.ott.productOrder.domain.model;
 
-public enum ProductOrderStaus {
+public enum ProductOrderStatus {
     ORDERED,
     PAID,
     CONFIRMED,

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/domain/repository/ProductOrderRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/domain/repository/ProductOrderRepository.java
@@ -13,7 +13,7 @@ public interface ProductOrderRepository {
 
     void deleteProductOrder(ProductOrder productOrder, User user);
 
-    void confirmProductOrder(ProductOrder productOrder, User user);
+    ProductOrder confirmProductOrder(ProductOrder productOrder, User user);
 
     void confirmProductOrder(ProductOrder productOrder);
 

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/infrastructure/entity/ProductOrderEntity.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/infrastructure/entity/ProductOrderEntity.java
@@ -1,7 +1,7 @@
 package com.kakaotech.ott.ott.productOrder.infrastructure.entity;
 
 import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrder;
-import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrderStaus;
+import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrderStatus;
 import com.kakaotech.ott.ott.user.infrastructure.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -32,7 +32,7 @@ public class ProductOrderEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 30)
-    private ProductOrderStaus status;
+    private ProductOrderStatus status;
 
     @Column(name = "subtotal_amount", nullable = false)
     private int subtotalAmount;
@@ -92,8 +92,8 @@ public class ProductOrderEntity {
         this.deletedAt = deletedAt;
     }
 
-    public void setStatus(ProductOrderStaus productOrderStaus) {
-        this.status = productOrderStaus;
+    public void setStatus(ProductOrderStatus productOrderStatus) {
+        this.status = productOrderStatus;
     }
 
     public void setDeliveredAt(LocalDateTime deliveredAt) {

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/infrastructure/repositoryImpl/ProductOrderRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/infrastructure/repositoryImpl/ProductOrderRepositoryImpl.java
@@ -3,7 +3,7 @@ package com.kakaotech.ott.ott.productOrder.infrastructure.repositoryImpl;
 import com.kakaotech.ott.ott.global.exception.CustomException;
 import com.kakaotech.ott.ott.global.exception.ErrorCode;
 import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrder;
-import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrderStaus;
+import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrderStatus;
 import com.kakaotech.ott.ott.productOrder.domain.repository.ProductOrderJpaRepository;
 import com.kakaotech.ott.ott.productOrder.domain.repository.ProductOrderRepository;
 import com.kakaotech.ott.ott.productOrder.infrastructure.entity.ProductOrderEntity;
@@ -46,13 +46,15 @@ public class ProductOrderRepositoryImpl implements ProductOrderRepository {
 
     @Override
     @Transactional
-    public void confirmProductOrder(ProductOrder productOrder, User user) {
+    public ProductOrder confirmProductOrder(ProductOrder productOrder, User user) {
 
         ProductOrderEntity beforeProductOrderEntity = productOrderJpaRepository.findByIdAndUserEntity_IdAndDeletedAtIsNull(productOrder.getId(), user.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
         beforeProductOrderEntity.setConfirmedAt(productOrder.getConfirmedAt());
         beforeProductOrderEntity.setStatus(productOrder.getStatus());
+
+        return productOrderJpaRepository.save(beforeProductOrderEntity).toDomain();
     }
 
     @Override
@@ -63,7 +65,7 @@ public class ProductOrderRepositoryImpl implements ProductOrderRepository {
                 .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
         beforeProductOrderEntity.setConfirmedAt(productOrder.getConfirmedAt());
-        beforeProductOrderEntity.setStatus(ProductOrderStaus.CONFIRMED);
+        beforeProductOrderEntity.setStatus(ProductOrderStatus.CONFIRMED);
     }
 
     @Override

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/presentation/controller/ProductOrderController.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/presentation/controller/ProductOrderController.java
@@ -3,10 +3,7 @@ package com.kakaotech.ott.ott.productOrder.presentation.controller;
 import com.kakaotech.ott.ott.global.response.ApiResponse;
 import com.kakaotech.ott.ott.productOrder.application.service.ProductOrderService;
 import com.kakaotech.ott.ott.productOrder.presentation.dto.request.ProductOrderRequestDto;
-import com.kakaotech.ott.ott.productOrder.presentation.dto.response.MyProductOrderHistoryListResponseDto;
-import com.kakaotech.ott.ott.productOrder.presentation.dto.response.MyProductOrderHistoryResponseDto;
-import com.kakaotech.ott.ott.productOrder.presentation.dto.response.MyProductOrderResponseDto;
-import com.kakaotech.ott.ott.productOrder.presentation.dto.response.ProductOrderResponseDto;
+import com.kakaotech.ott.ott.productOrder.presentation.dto.response.*;
 import com.kakaotech.ott.ott.user.domain.model.UserPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -71,15 +68,15 @@ public class ProductOrderController {
     }
 
     @PostMapping("/{orderId}/confirm")
-    public ResponseEntity<ApiResponse> confirmOrder(
+    public ResponseEntity<ApiResponse<ProductOrderConfirmResponseDto>> confirmOrder(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long orderId) {
 
         Long userId = userPrincipal.getId();
 
-        productOrderService.confirmProductOrder(userId, orderId);
+        ProductOrderConfirmResponseDto productOrderConfirmResponseDto = productOrderService.confirmProductOrder(userId, orderId);
 
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("구매 확정 완료", orderId));
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("구매 확정 완료", productOrderConfirmResponseDto));
     }
 
 }

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/presentation/dto/response/ProductOrderConfirmResponseDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/presentation/dto/response/ProductOrderConfirmResponseDto.java
@@ -1,0 +1,17 @@
+package com.kakaotech.ott.ott.productOrder.presentation.dto.response;
+
+import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrderStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductOrderConfirmResponseDto {
+
+    private Long orderId;
+    private ProductOrderStatus status;
+}

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/presentation/dto/response/ProductOrderResponseDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/presentation/dto/response/ProductOrderResponseDto.java
@@ -1,6 +1,6 @@
 package com.kakaotech.ott.ott.productOrder.presentation.dto.response;
 
-import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrderStaus;
+import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrderStatus;
 import com.kakaotech.ott.ott.productOrder.presentation.dto.request.ServiceProductDto;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -27,7 +27,7 @@ public class ProductOrderResponseDto {
     private int totalAmount;
 
     @NotNull
-    private ProductOrderStaus status;
+    private ProductOrderStatus status;
 
     @NotNull
     private LocalDateTime createdAt;


### PR DESCRIPTION
### feat: 주문 확정 dto 추가

### 설명
- 주문 확정 시 응답 dto 추가
- orderId, status 응답=

### 테스트 방법
1. IDE 서버 실행  
2. Postman에서 `POST /api/v1/orders/{orderId}/confirm` 호출  
