### PR TITLE
feat: 주문 취소와 내역 취소 기능 분리

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/global/exception/ErrorCode.java
+++ b/src/main/java/com/kakaotech/ott/ott/global/exception/ErrorCode.java
@@ -58,12 +58,14 @@ public enum ErrorCode {
     NOT_ORDERED_STATE(HttpStatus.BAD_REQUEST, "주문 대기 상태가 아닙니다."),
     NOT_PAID_STATE(HttpStatus.BAD_REQUEST, "결제 완료 상태가 아닙니다."),
     NOT_DELIVERED_STATE(HttpStatus.BAD_REQUEST, "배송 완료된 상태가 아닙니다."),
+    NOT_CANCELABLE_STATE(HttpStatus.BAD_REQUEST, "취소 가능한 상태가 아닙니다."),
 
     ALREADY_ORDERED(HttpStatus.BAD_REQUEST, "이미 주문된 상태입니다."),
     ALREADY_PAID(HttpStatus.BAD_REQUEST, "이미 결제된 주문입니다."),
     ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "이미 확정된 주문입니다."),
     ALREADY_DELIVERED(HttpStatus.BAD_REQUEST, "이미 배송된 주문입니다."),
     ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 주문내역입니다."),
+
 
     // ORDERITEM
     NOT_ORDERED_ITEM_STATE(HttpStatus.BAD_REQUEST, "주문 대기 상태가 아닙니다."),

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/application/service/ProductOrderService.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/application/service/ProductOrderService.java
@@ -17,4 +17,6 @@ public interface ProductOrderService {
     void deleteProductOrder(Long userId, Long orderId);
 
     ProductOrderConfirmResponseDto confirmProductOrder(Long userId, Long orderId);
+
+    void cancelProductOrder(Long userId, Long orderId);
 }

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/application/serviceimpl/ProductOrderServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/application/serviceimpl/ProductOrderServiceImpl.java
@@ -155,5 +155,15 @@ public class ProductOrderServiceImpl implements ProductOrderService {
         return new ProductOrderConfirmResponseDto(productOrder.getId(), productOrder.getStatus());
     }
 
+    @Override
+    public void cancelProductOrder(Long userId, Long orderId) {
+
+        User user = userRepository.findById(userId);
+
+        ProductOrder productOrder = productOrderRepository.findByIdAndUserId(orderId, userId);
+        productOrder.cancel();
+
+        productOrderRepository.cancelProductOrder(productOrder, user);
+    }
 
 }

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/domain/model/ProductOrder.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/domain/model/ProductOrder.java
@@ -74,11 +74,7 @@ public class ProductOrder {
     }
 
     public void cancel() {
-        if (this.status != ProductOrderStatus.PAID) throw new CustomException(ErrorCode.NOT_PAID_STATE);
-
-        if (this.status == ProductOrderStatus.DELIVERED) throw new CustomException(ErrorCode.ALREADY_DELIVERED);
-
-        if (this.status == ProductOrderStatus.CONFIRMED) throw new CustomException(ErrorCode.ALREADY_CONFIRMED);
+        if (this.status != ProductOrderStatus.PAID) throw new CustomException(ErrorCode.NOT_CANCELABLE_STATE);
 
         this.canceledAt = LocalDateTime.now();
         this.status = ProductOrderStatus.CANCELED;

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/domain/repository/ProductOrderRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/domain/repository/ProductOrderRepository.java
@@ -17,6 +17,8 @@ public interface ProductOrderRepository {
 
     void confirmProductOrder(ProductOrder productOrder);
 
+    void cancelProductOrder(ProductOrder productOrder, User user);
+
     Slice<ProductOrder> findAllByUserId(Long userId, Long lastOrderId, int size);
 
     ProductOrder findByIdAndUserId(Long orderId, Long userId);

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/infrastructure/repositoryImpl/ProductOrderRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/infrastructure/repositoryImpl/ProductOrderRepositoryImpl.java
@@ -69,6 +69,18 @@ public class ProductOrderRepositoryImpl implements ProductOrderRepository {
     }
 
     @Override
+    @Transactional
+    public void cancelProductOrder(ProductOrder productOrder, User user) {
+
+        ProductOrderEntity beforeProductOrderEntity = productOrderJpaRepository.findByIdAndUserEntity_IdAndDeletedAtIsNull(
+                productOrder.getId(), user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        beforeProductOrderEntity.setCanceledAt(productOrder.getCanceledAt());
+        beforeProductOrderEntity.setStatus(productOrder.getStatus());
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public Slice<ProductOrder> findAllByUserId(Long userId, Long lastOrderId, int size) {
 

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/presentation/controller/ProductOrderController.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/presentation/controller/ProductOrderController.java
@@ -55,7 +55,7 @@ public class ProductOrderController {
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("주문 정보 조회 성공", myProductOrderResponseDto));
     }
 
-    @DeleteMapping("/{orderId}")
+    @PostMapping("/{orderId}")
     public ResponseEntity<ApiResponse> deleteOrder(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long orderId) {
@@ -64,7 +64,7 @@ public class ProductOrderController {
 
         productOrderService.deleteProductOrder(userId, orderId);
 
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("주문 취소 성공", null));
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("주문 내역 삭제 완료", null));
     }
 
     @PostMapping("/{orderId}/confirm")
@@ -77,6 +77,18 @@ public class ProductOrderController {
         ProductOrderConfirmResponseDto productOrderConfirmResponseDto = productOrderService.confirmProductOrder(userId, orderId);
 
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("구매 확정 완료", productOrderConfirmResponseDto));
+    }
+
+    @DeleteMapping("/{orderId}")
+    public ResponseEntity<ApiResponse> cancelOrder(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long orderId) {
+
+        Long userId = userPrincipal.getId();
+
+        productOrderService.cancelProductOrder(userId, orderId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("주문 취소 완료", null));
     }
 
 }


### PR DESCRIPTION
### feat: 주문 취소와 내역 취소 기능 분리

### 설명
- 주문 취소와 주문 내역 삭제의 기능을 분리
- 주문 취소는 status를 PAID -> CANCEL로 변경, 주문 내역 삭제는 deleted_at 값 활성화(Soft delete)

### 테스트 방법
1. IDE 서버 실행  
2. Postman에서 `POST /api/v1/orders/{orderId}` 호출  
3. 'status' 변경 확인