### PR TITLE
feat: 나의 스크랩 목록 조회 기능 완료

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/global/exception/ErrorCode.java
+++ b/src/main/java/com/kakaotech/ott/ott/global/exception/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     INVALID_IMAGE(HttpStatus.BAD_REQUEST, "올바른 데스크 이미지가 아닙니다."),
 
     // Product
+    DESK_PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 데스크 추천 상품이 존재하지 않습니다."),
     AI_PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 AI 이미지에 대한 추천 상품이 존재하지 않습니다."),
 
     // Scrap

--- a/src/main/java/com/kakaotech/ott/ott/product/domain/repository/DeskProductRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/domain/repository/DeskProductRepository.java
@@ -15,4 +15,6 @@ public interface DeskProductRepository {
     List<DeskProduct> findTop7ByWeight();
 
     void incrementScrapCount(Long postId, Long delta);
+
+    DeskProduct findById(Long deskProductId);
 }

--- a/src/main/java/com/kakaotech/ott/ott/product/infrastructure/repositoryImpl/DeskProductRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/infrastructure/repositoryImpl/DeskProductRepositoryImpl.java
@@ -61,4 +61,12 @@ public class DeskProductRepositoryImpl implements DeskProductRepository {
 
         deskProductJpaRepository.incrementScrapCount(targetId, delta);
     }
+
+    @Override
+    public DeskProduct findById(Long deskProductId) {
+
+        return deskProductJpaRepository.findById(deskProductId)
+                .orElseThrow(() -> new CustomException(ErrorCode.DESK_PRODUCT_NOT_FOUND))
+                .toDomain();
+    }
 }

--- a/src/main/java/com/kakaotech/ott/ott/scrap/domain/repository/ScrapJpaRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/scrap/domain/repository/ScrapJpaRepository.java
@@ -2,6 +2,8 @@ package com.kakaotech.ott.ott.scrap.domain.repository;
 
 import com.kakaotech.ott.ott.scrap.domain.model.ScrapType;
 import com.kakaotech.ott.ott.scrap.infrastructure.entity.ScrapEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -23,4 +25,15 @@ public interface ScrapJpaRepository extends JpaRepository<ScrapEntity, Long> {
 
     @Query("SELECT COUNT(s) FROM ScrapEntity s WHERE s.targetId = :postId AND s.type = :type")
     int countByPostId(@Param("postId") Long postId);
+
+    // 나의 스크랩 조회
+    @Query("""
+    SELECT DISTINCT s 
+    FROM ScrapEntity s 
+    LEFT JOIN FETCH s.userEntity u 
+    WHERE u.id = :userId 
+      AND (:lastScrapId IS NULL OR s.id < :lastScrapId) 
+    ORDER BY s.id DESC
+""")
+    Page<ScrapEntity> findUserAllScraps(@Param("userId") Long userId, @Param("lastScrapId") Long lastPostId, Pageable pageable);
 }

--- a/src/main/java/com/kakaotech/ott/ott/scrap/domain/repository/ScrapRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/scrap/domain/repository/ScrapRepository.java
@@ -1,7 +1,9 @@
 package com.kakaotech.ott.ott.scrap.domain.repository;
 
+import com.kakaotech.ott.ott.post.domain.model.Post;
 import com.kakaotech.ott.ott.scrap.domain.model.Scrap;
 import com.kakaotech.ott.ott.scrap.domain.model.ScrapType;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 import java.util.Set;
@@ -17,4 +19,6 @@ public interface ScrapRepository {
     Set<Long> findScrappedPostIds(Long userId, List<Long> postIds);
 
     int findByPostId(Long postId, ScrapType type);
+
+    Slice<Scrap> findUserScrap(Long userId, Long cursorId, int size);
 }

--- a/src/main/java/com/kakaotech/ott/ott/scrap/infrastructure/repositoryImpl/ScrapRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/scrap/infrastructure/repositoryImpl/ScrapRepositoryImpl.java
@@ -9,13 +9,14 @@ import com.kakaotech.ott.ott.user.infrastructure.entity.UserEntity;
 import com.kakaotech.ott.ott.user.domain.repository.UserJpaRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -57,6 +58,14 @@ public class ScrapRepositoryImpl implements ScrapRepository {
     @Override
     public int findByPostId(Long postId, ScrapType type) {
         return scrapJpaRepository.countByPostId(postId);
+    }
+
+    @Override
+    public Slice<Scrap> findUserScrap(Long userId, Long cursorId, int size) {
+
+        Slice<ScrapEntity> slice = scrapJpaRepository.findUserAllScraps(userId, cursorId, PageRequest.of(0, size));
+
+        return slice.map(ScrapEntity::toDomain);
     }
 
 }

--- a/src/main/java/com/kakaotech/ott/ott/user/application/service/UserService.java
+++ b/src/main/java/com/kakaotech/ott/ott/user/application/service/UserService.java
@@ -2,10 +2,7 @@ package com.kakaotech.ott.ott.user.application.service;
 
 import com.kakaotech.ott.ott.user.presentation.dto.request.UserInfoUpdateRequestDto;
 import com.kakaotech.ott.ott.user.presentation.dto.request.UserVerifiedRequestDto;
-import com.kakaotech.ott.ott.user.presentation.dto.response.MyDeskImageResponseDto;
-import com.kakaotech.ott.ott.user.presentation.dto.response.MyInfoResponseDto;
-import com.kakaotech.ott.ott.user.presentation.dto.response.MyPostResponseDto;
-import com.kakaotech.ott.ott.user.presentation.dto.response.UserInfoUpdateResponseDto;
+import com.kakaotech.ott.ott.user.presentation.dto.response.*;
 
 import java.io.IOException;
 
@@ -17,6 +14,8 @@ public interface UserService {
 
     MyPostResponseDto getMyPost(Long userId, Long lastId, int size);
 
+    MyScrapResponseDto getMyScrap(Long userId, Long lastId, int size);
+
     UserInfoUpdateResponseDto updateUserInfo(Long userId, UserInfoUpdateRequestDto userInfoUpdateRequestDto) throws IOException;
 
     void deleteUser(Long userId);
@@ -24,4 +23,5 @@ public interface UserService {
     void verifiedCode(Long userId, UserVerifiedRequestDto userVerifiedRequestDto);
 
     void recoverUser(Long userId);
+
 }

--- a/src/main/java/com/kakaotech/ott/ott/user/application/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/user/application/serviceImpl/UserServiceImpl.java
@@ -3,7 +3,6 @@ package com.kakaotech.ott.ott.user.application.serviceImpl;
 import com.kakaotech.ott.ott.aiImage.application.service.ImageUploader;
 import com.kakaotech.ott.ott.aiImage.domain.model.AiImage;
 import com.kakaotech.ott.ott.aiImage.domain.repository.AiImageRepository;
-import com.kakaotech.ott.ott.comment.domain.repository.CommentRepository;
 import com.kakaotech.ott.ott.global.exception.CustomException;
 import com.kakaotech.ott.ott.global.exception.ErrorCode;
 import com.kakaotech.ott.ott.like.domain.repository.LikeRepository;
@@ -12,6 +11,9 @@ import com.kakaotech.ott.ott.post.domain.model.Post;
 import com.kakaotech.ott.ott.post.domain.repository.PostRepository;
 import com.kakaotech.ott.ott.post.presentation.dto.response.PostAllResponseDto;
 import com.kakaotech.ott.ott.post.presentation.dto.response.PostAuthorResponseDto;
+import com.kakaotech.ott.ott.product.domain.model.DeskProduct;
+import com.kakaotech.ott.ott.product.domain.repository.DeskProductRepository;
+import com.kakaotech.ott.ott.scrap.domain.model.Scrap;
 import com.kakaotech.ott.ott.scrap.domain.model.ScrapType;
 import com.kakaotech.ott.ott.scrap.domain.repository.ScrapRepository;
 import com.kakaotech.ott.ott.user.application.service.UserService;
@@ -19,13 +21,9 @@ import com.kakaotech.ott.ott.user.domain.model.User;
 import com.kakaotech.ott.ott.user.domain.repository.UserRepository;
 import com.kakaotech.ott.ott.user.presentation.dto.request.UserInfoUpdateRequestDto;
 import com.kakaotech.ott.ott.user.presentation.dto.request.UserVerifiedRequestDto;
-import com.kakaotech.ott.ott.user.presentation.dto.response.MyDeskImageResponseDto;
-import com.kakaotech.ott.ott.user.presentation.dto.response.MyInfoResponseDto;
-import com.kakaotech.ott.ott.user.presentation.dto.response.MyPostResponseDto;
-import com.kakaotech.ott.ott.user.presentation.dto.response.UserInfoUpdateResponseDto;
+import com.kakaotech.ott.ott.user.presentation.dto.response.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,7 +32,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -47,8 +44,8 @@ public class UserServiceImpl implements UserService {
     private final ImageUploader imageUploader;
     private final PostRepository postRepository;
     private final LikeRepository likeRepository;
-    private final CommentRepository commentRepository;
     private final ScrapRepository scrapRepository;
+    private final DeskProductRepository deskProductRepository;
 
     @Value("${verified.code}")
     private String verifiedCode;
@@ -161,6 +158,51 @@ public class UserServiceImpl implements UserService {
                 postSlice.hasNext());
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public MyScrapResponseDto getMyScrap(Long userId, Long lastId, int size) {
+
+        Slice<Scrap> scrapSlice = scrapRepository.findUserScrap(userId, lastId, size);
+
+        List<Long> scrapIds = scrapSlice.getContent().stream()
+                .map(Scrap::getId)
+                .toList();
+
+        List<MyScrapResponseDto.Scraps> scraps = scrapSlice.getContent().stream()
+                .map(scrap -> {
+                    String thumbnailImage;
+                    if(scrap.getType().equals(ScrapType.POST)) {
+                        Post post = postRepository.findById(scrap.getTargetId());
+                        thumbnailImage = post.getImages().isEmpty()
+                                ? null
+                                : post.getImages().get(0).getImageUuid();
+                    } else {
+                        DeskProduct deskProduct = deskProductRepository.findById(scrap.getTargetId());
+                        thumbnailImage = deskProduct.getImagePath();
+                    }
+
+
+                    return new MyScrapResponseDto.Scraps(
+                            scrap.getId(),
+                            scrap.getType(),
+                            scrap.getTargetId(),
+                            thumbnailImage,
+                            true
+                    );
+
+                })
+                .toList();
+
+        MyScrapResponseDto.Pagination pagination = new MyScrapResponseDto.Pagination(
+                size,
+                scrapSlice.hasNext() ? scrapSlice.getContent().get(scrapSlice.getNumberOfElements() - 1).getId() : null,
+                scrapSlice.hasNext()
+        );
+
+        return new MyScrapResponseDto(scraps, pagination);
+
+
+    }
 
 
     @Override
@@ -251,6 +293,5 @@ public class UserServiceImpl implements UserService {
 
         userRepository.recovery(user);
     }
-
 
 }

--- a/src/main/java/com/kakaotech/ott/ott/user/presentation/controller/UserController.java
+++ b/src/main/java/com/kakaotech/ott/ott/user/presentation/controller/UserController.java
@@ -5,10 +5,7 @@ import com.kakaotech.ott.ott.user.application.service.UserService;
 import com.kakaotech.ott.ott.user.domain.model.UserPrincipal;
 import com.kakaotech.ott.ott.user.presentation.dto.request.UserInfoUpdateRequestDto;
 import com.kakaotech.ott.ott.user.presentation.dto.request.UserVerifiedRequestDto;
-import com.kakaotech.ott.ott.user.presentation.dto.response.MyDeskImageResponseDto;
-import com.kakaotech.ott.ott.user.presentation.dto.response.MyInfoResponseDto;
-import com.kakaotech.ott.ott.user.presentation.dto.response.MyPostResponseDto;
-import com.kakaotech.ott.ott.user.presentation.dto.response.UserInfoUpdateResponseDto;
+import com.kakaotech.ott.ott.user.presentation.dto.response.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -78,6 +75,20 @@ public class UserController {
 
         return ResponseEntity.ok(ApiResponse.success("회원 정보 수정 성공", userInfoUpdateResponseDto));
     }
+
+    @GetMapping("/me/scraps")
+    public ResponseEntity<ApiResponse<MyScrapResponseDto>> getMyScrap(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam (value = "cursorId", required = false) Long cursorId,
+            @RequestParam(defaultValue = "10") int size) {
+
+        Long userId = userPrincipal.getId();
+
+        MyScrapResponseDto myScrapResponseDto = userService.getMyScrap(userId, cursorId, size);
+
+        return ResponseEntity.ok(ApiResponse.success("스크랩 목록 조회 성공", myScrapResponseDto));
+    }
+
 
     @DeleteMapping
     public ResponseEntity<ApiResponse> deleteUser(

--- a/src/main/java/com/kakaotech/ott/ott/user/presentation/dto/response/MyScrapResponseDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/user/presentation/dto/response/MyScrapResponseDto.java
@@ -1,0 +1,41 @@
+package com.kakaotech.ott.ott.user.presentation.dto.response;
+
+import com.kakaotech.ott.ott.scrap.domain.model.ScrapType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MyScrapResponseDto {
+
+    private List<Scraps> scraps;
+    private Pagination pagination;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Scraps {
+
+        private Long scrapId;
+        private ScrapType type;
+        private Long targetId;
+        private String thumbnailUrl;
+        private boolean scrapped;
+
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Pagination {
+        private int size;
+        private Long lastScrapId;
+        private boolean hasNext;
+    }
+}


### PR DESCRIPTION
### feat: 나의 스크랩 목록 조회 기능 완료

### 설명
- 나의 스크랩 목록 조회 기능
- 스크랩 종류(POST, PRODUCT)에 대해서 일관된 데이터를 반환

### 테스트 방법
1. IDE 서버 실행  
2. Postman에서 `GET /api/v1/users/scraps` 호출  
3. 자신의 스크랩 목록이 정상적으로 반환되는지 확인