### PR TITLE
feat: 포인트 내역 조회 기능 완료

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/pointHistory/domain/model/PointActionType.java
+++ b/src/main/java/com/kakaotech/ott/ott/pointHistory/domain/model/PointActionType.java
@@ -1,0 +1,6 @@
+package com.kakaotech.ott.ott.pointHistory.domain.model;
+
+public enum PointActionType {
+    EARN,   //적립
+    DEDUCT  //차감
+}

--- a/src/main/java/com/kakaotech/ott/ott/pointHistory/domain/model/PointHistory.java
+++ b/src/main/java/com/kakaotech/ott/ott/pointHistory/domain/model/PointHistory.java
@@ -1,0 +1,34 @@
+package com.kakaotech.ott.ott.pointHistory.domain.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PointHistory {
+
+    private Long id;
+    private Long userId;
+
+    private int amount;
+    private int balanceAfter;
+
+    private PointActionType type;
+
+    private String description;
+
+    private LocalDateTime createdAt;
+
+    public PointHistory createPointHistory(Long userId, int amount, int balanceAfter, PointActionType type, String description) {
+
+        return PointHistory.builder()
+                .userId(userId)
+                .amount(amount)
+                .balanceAfter(balanceAfter)
+                .type(type)
+                .description(description)
+                .build();
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/pointHistory/domain/repository/PointHistoryJpaRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/pointHistory/domain/repository/PointHistoryJpaRepository.java
@@ -1,0 +1,21 @@
+package com.kakaotech.ott.ott.pointHistory.domain.repository;
+
+import com.kakaotech.ott.ott.pointHistory.infrastructure.entity.PointHistoryEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PointHistoryJpaRepository extends JpaRepository<PointHistoryEntity, Long> {
+
+    @Query("""
+    SELECT DISTINCT p 
+    FROM PointHistoryEntity p 
+    LEFT JOIN FETCH p.userEntity u 
+    WHERE u.id = :userId 
+      AND (:lastPointHistoryId IS NULL OR p.id < :lastPointHistoryId) 
+    ORDER BY p.id DESC
+""")
+    Page<PointHistoryEntity> findUserAllPointHistory(@Param("userId") Long userId, @Param("lastPointHistoryId") Long lastPointHistoryId, Pageable pageable);
+}

--- a/src/main/java/com/kakaotech/ott/ott/pointHistory/domain/repository/PointHistoryRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/pointHistory/domain/repository/PointHistoryRepository.java
@@ -1,0 +1,9 @@
+package com.kakaotech.ott.ott.pointHistory.domain.repository;
+
+import com.kakaotech.ott.ott.pointHistory.domain.model.PointHistory;
+import org.springframework.data.domain.Slice;
+
+public interface PointHistoryRepository {
+
+    Slice<PointHistory> findUserPointHistory(Long userId, Long cursorId, int size);
+}

--- a/src/main/java/com/kakaotech/ott/ott/pointHistory/infrastructure/entity/PointHistoryEntity.java
+++ b/src/main/java/com/kakaotech/ott/ott/pointHistory/infrastructure/entity/PointHistoryEntity.java
@@ -1,0 +1,71 @@
+package com.kakaotech.ott.ott.pointHistory.infrastructure.entity;
+
+import com.kakaotech.ott.ott.pointHistory.domain.model.PointActionType;
+import com.kakaotech.ott.ott.pointHistory.domain.model.PointHistory;
+import com.kakaotech.ott.ott.user.infrastructure.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "point_history")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+public class PointHistoryEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id") // FK 컬럼명
+    private UserEntity userEntity;
+
+    @Column(name = "amount", nullable = false)
+    private int amount;
+
+    @Column(name = "balance_after", nullable = false)
+    private int balanceAfter;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private PointActionType type;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    LocalDateTime createdAt;
+
+    public PointHistoryEntity from(PointHistory pointHistory, UserEntity userEntity) {
+
+        return PointHistoryEntity.builder()
+                .userEntity(userEntity)
+                .amount(pointHistory.getAmount())
+                .balanceAfter(pointHistory.getBalanceAfter())
+                .type(pointHistory.getType())
+                .description(pointHistory.getDescription())
+                .build();
+    }
+
+    public PointHistory toDomain() {
+
+        return PointHistory.builder()
+                .id(this.getId())
+                .userId(this.getUserEntity().getId())
+                .amount(this.getAmount())
+                .balanceAfter(this.getBalanceAfter())
+                .type(this.getType())
+                .description(this.getDescription())
+                .createdAt(this.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/pointHistory/infrastructure/repositoryImpl/PointHistoryRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/pointHistory/infrastructure/repositoryImpl/PointHistoryRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.kakaotech.ott.ott.pointHistory.infrastructure.repositoryImpl;
+
+import com.kakaotech.ott.ott.pointHistory.domain.model.PointHistory;
+import com.kakaotech.ott.ott.pointHistory.domain.repository.PointHistoryJpaRepository;
+import com.kakaotech.ott.ott.pointHistory.domain.repository.PointHistoryRepository;
+import com.kakaotech.ott.ott.pointHistory.infrastructure.entity.PointHistoryEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class PointHistoryRepositoryImpl implements PointHistoryRepository {
+
+    private final PointHistoryJpaRepository pointHistoryJpaRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Slice<PointHistory> findUserPointHistory(Long userId, Long cursorId, int size) {
+
+        Slice<PointHistoryEntity> slice = pointHistoryJpaRepository.findUserAllPointHistory(userId, cursorId, PageRequest.of(0, size));
+
+        return slice.map(PointHistoryEntity::toDomain);
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/user/application/service/UserService.java
+++ b/src/main/java/com/kakaotech/ott/ott/user/application/service/UserService.java
@@ -16,6 +16,8 @@ public interface UserService {
 
     MyScrapResponseDto getMyScrap(Long userId, Long lastId, int size);
 
+    MyPointHistoryResponseDto getMyPointHistory(Long userId, Long lastId, int size);
+
     UserInfoUpdateResponseDto updateUserInfo(Long userId, UserInfoUpdateRequestDto userInfoUpdateRequestDto) throws IOException;
 
     void deleteUser(Long userId);

--- a/src/main/java/com/kakaotech/ott/ott/user/application/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/user/application/serviceImpl/UserServiceImpl.java
@@ -6,6 +6,9 @@ import com.kakaotech.ott.ott.aiImage.domain.repository.AiImageRepository;
 import com.kakaotech.ott.ott.global.exception.CustomException;
 import com.kakaotech.ott.ott.global.exception.ErrorCode;
 import com.kakaotech.ott.ott.like.domain.repository.LikeRepository;
+import com.kakaotech.ott.ott.pointHistory.domain.model.PointActionType;
+import com.kakaotech.ott.ott.pointHistory.domain.model.PointHistory;
+import com.kakaotech.ott.ott.pointHistory.domain.repository.PointHistoryRepository;
 import com.kakaotech.ott.ott.post.domain.model.MyDeskState;
 import com.kakaotech.ott.ott.post.domain.model.Post;
 import com.kakaotech.ott.ott.post.domain.repository.PostRepository;
@@ -46,6 +49,7 @@ public class UserServiceImpl implements UserService {
     private final LikeRepository likeRepository;
     private final ScrapRepository scrapRepository;
     private final DeskProductRepository deskProductRepository;
+    private final PointHistoryRepository pointHistoryRepository;
 
     @Value("${verified.code}")
     private String verifiedCode;
@@ -201,6 +205,39 @@ public class UserServiceImpl implements UserService {
 
         return new MyScrapResponseDto(scraps, pagination);
 
+
+    }
+
+    @Override
+    @Transactional
+    public MyPointHistoryResponseDto getMyPointHistory(Long userId, Long lastId, int size) {
+        Slice<PointHistory> pointHistorySlice = pointHistoryRepository.findUserPointHistory(userId, lastId, size);
+
+        List<Long> PointHistoryIds = pointHistorySlice.getContent().stream()
+                .map(PointHistory::getId)
+                .toList();
+
+        List<MyPointHistoryResponseDto.PointInfo> pointInfos = pointHistorySlice.getContent().stream()
+                .map(pointHistory -> {
+                    return new MyPointHistoryResponseDto.PointInfo(
+                            pointHistory.getId(),
+                            pointHistory.getDescription(),
+                            pointHistory.getType(),
+                            pointHistory.getAmount(),
+                            pointHistory.getBalanceAfter(),
+                            pointHistory.getCreatedAt()
+                    );
+
+                })
+                .toList();
+
+        MyPointHistoryResponseDto.Pagination pagination = new MyPointHistoryResponseDto.Pagination(
+                size,
+                pointHistorySlice.hasNext() ? pointHistorySlice.getContent().get(pointHistorySlice.getNumberOfElements() - 1).getId() : null,
+                pointHistorySlice.hasNext()
+        );
+
+        return new MyPointHistoryResponseDto(pointInfos, pagination);
 
     }
 

--- a/src/main/java/com/kakaotech/ott/ott/user/presentation/controller/UserController.java
+++ b/src/main/java/com/kakaotech/ott/ott/user/presentation/controller/UserController.java
@@ -89,6 +89,19 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success("스크랩 목록 조회 성공", myScrapResponseDto));
     }
 
+    @GetMapping("/point")
+    public ResponseEntity<ApiResponse<MyPointHistoryResponseDto>> getMyPointHistory(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam (value = "cursorId", required = false) Long cursorId,
+            @RequestParam (defaultValue = "10") int size) {
+
+        Long userId = userPrincipal.getId();
+
+        MyPointHistoryResponseDto myPointHistoryResponseDto = userService.getMyPointHistory(userId, cursorId, size);
+
+        return ResponseEntity.ok(ApiResponse.success("포인트 내역 조회 성공", myPointHistoryResponseDto));
+    }
+
 
     @DeleteMapping
     public ResponseEntity<ApiResponse> deleteUser(

--- a/src/main/java/com/kakaotech/ott/ott/user/presentation/dto/response/MyPointHistoryResponseDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/user/presentation/dto/response/MyPointHistoryResponseDto.java
@@ -1,0 +1,41 @@
+package com.kakaotech.ott.ott.user.presentation.dto.response;
+
+import com.kakaotech.ott.ott.pointHistory.domain.model.PointActionType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MyPointHistoryResponseDto {
+
+    private List<PointInfo> point;
+    private MyPointHistoryResponseDto.Pagination pagination;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PointInfo {
+        private Long historyId;
+        private String description;
+        private PointActionType type;
+        private int amount;
+        private int balance_after;
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Pagination {
+        private int size;
+        private Long lastPointHistoryId;
+        private boolean hasNext;
+    }
+}


### PR DESCRIPTION
### feat: 포인트 내역 조회 기능 완료

### 설명
- 포인트 내역 조회 기능 개발
- 커서 기반 페이지네이션 적용
- 사용자의 적립 및 차감에 대한 포인트 내역 조회
- 적립 또는 차감된 포인트량, 이전 포인트량, 적립 사유 등 조회

### 테스트 방법
1. IDE 서버 실행  
2. Postman에서 `GET /api/v1/users/point` 호출  
3. 포인트 내역이 정상적으로 반환되는지 확인
