### PR TITLE
feat: 이미지 생성 가능 토큰수 수정

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/aiImage/domain/model/ImageGenerationHistory.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/domain/model/ImageGenerationHistory.java
@@ -1,0 +1,31 @@
+package com.kakaotech.ott.ott.aiImage.domain.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ImageGenerationHistory {
+
+    private Long id;
+
+    private Long userId;
+
+    private LocalDate dateKey;
+
+    private String promptSummary;
+
+    private LocalDateTime generatedAt;
+
+    public static ImageGenerationHistory createImageGenerationHisotry(Long userId, LocalDate dateKey, String promptSummary) {
+
+        return ImageGenerationHistory.builder()
+                .userId(userId)
+                .dateKey(dateKey)
+                .promptSummary(promptSummary)
+                .build();
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/aiImage/domain/repository/ImageGenerationHistoryJpaRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/domain/repository/ImageGenerationHistoryJpaRepository.java
@@ -1,0 +1,11 @@
+package com.kakaotech.ott.ott.aiImage.domain.repository;
+
+import com.kakaotech.ott.ott.aiImage.infrastructure.entity.ImageGenerationHistoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+
+public interface ImageGenerationHistoryJpaRepository extends JpaRepository<ImageGenerationHistoryEntity, Long> {
+
+    int countByUserEntity_IdAndDateKey(Long userId, LocalDate dateKey);
+}

--- a/src/main/java/com/kakaotech/ott/ott/aiImage/domain/repository/ImageGenerationHistoryRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/domain/repository/ImageGenerationHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.kakaotech.ott.ott.aiImage.domain.repository;
+
+import java.time.LocalDate;
+
+public interface ImageGenerationHistoryRepository {
+
+    int checkGenerationTokenCount(Long userId, LocalDate dateKey);
+}

--- a/src/main/java/com/kakaotech/ott/ott/aiImage/infrastructure/entity/ImageGenerationHistoryEntity.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/infrastructure/entity/ImageGenerationHistoryEntity.java
@@ -1,0 +1,59 @@
+package com.kakaotech.ott.ott.aiImage.infrastructure.entity;
+
+import com.kakaotech.ott.ott.aiImage.domain.model.ImageGenerationHistory;
+import com.kakaotech.ott.ott.user.infrastructure.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "image_generation_history")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class ImageGenerationHistoryEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id") // FK 컬럼명
+    private UserEntity userEntity;
+
+    @Column(name = "date_key", nullable = false)
+    private LocalDate dateKey;
+
+    @Column(name = "prompt_summary")
+    private String promptSummary;
+
+    @CreatedDate
+    @Column(name = "generated_at", nullable = false)
+    private LocalDateTime generatedAt;
+
+    public static ImageGenerationHistoryEntity from(ImageGenerationHistory imageGenerationHistory, UserEntity userEntity) {
+
+        return ImageGenerationHistoryEntity.builder()
+                .userEntity(userEntity)
+                .dateKey(imageGenerationHistory.getDateKey())
+                .promptSummary(imageGenerationHistory.getPromptSummary())
+                .build();
+    }
+
+    public ImageGenerationHistory toDomain() {
+
+        return ImageGenerationHistory.builder()
+                .id(this.getId())
+                .userId(this.getUserEntity().getId())
+                .dateKey(this.getDateKey())
+                .promptSummary(this.getPromptSummary())
+                .generatedAt(this.getGeneratedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/aiImage/infrastructure/repositoryImpl/ImageGenerationHistoryRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/infrastructure/repositoryImpl/ImageGenerationHistoryRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.kakaotech.ott.ott.aiImage.infrastructure.repositoryImpl;
+
+import com.kakaotech.ott.ott.aiImage.domain.repository.ImageGenerationHistoryJpaRepository;
+import com.kakaotech.ott.ott.aiImage.domain.repository.ImageGenerationHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+
+@Repository
+@RequiredArgsConstructor
+public class ImageGenerationHistoryRepositoryImpl implements ImageGenerationHistoryRepository {
+
+    private final ImageGenerationHistoryJpaRepository imageGenerationHistoryJpaRepository;
+
+    @Override
+    public int checkGenerationTokenCount(Long userId, LocalDate dateKey) {
+
+        return imageGenerationHistoryJpaRepository.countByUserEntity_IdAndDateKey(userId, dateKey);
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/user/application/serviceImpl/UserAuthServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/user/application/serviceImpl/UserAuthServiceImpl.java
@@ -1,5 +1,6 @@
 package com.kakaotech.ott.ott.user.application.serviceImpl;
 
+import com.kakaotech.ott.ott.aiImage.domain.repository.ImageGenerationHistoryRepository;
 import com.kakaotech.ott.ott.aiImage.presentation.dto.response.CheckAiImageQuotaResponseDto;
 import com.kakaotech.ott.ott.global.exception.CustomException;
 import com.kakaotech.ott.ott.global.exception.ErrorCode;
@@ -25,6 +26,7 @@ public class UserAuthServiceImpl implements UserAuthService {
     private final UserAuthRepository userAuthRepository;
     private final KakaoLogoutServiceImpl kakaoLogoutService;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final ImageGenerationHistoryRepository imageGenerationHistoryRepository;
 
     @Transactional(readOnly = true)
     public CheckAiImageQuotaResponseDto remainQuota(Long userId) {
@@ -37,13 +39,9 @@ public class UserAuthServiceImpl implements UserAuthService {
         // 1. 사용자가 존재하지 않으면 예외 발생 (404)
         User user = userAuthRepository.findById(userId);
 
-        LocalDate lastGenerated = user.getAiImageGeneratedDate();
+        int usedToken = imageGenerationHistoryRepository.checkGenerationTokenCount(user.getId(), today);
 
-        if (lastGenerated != null && today.equals(lastGenerated))
-            return new CheckAiImageQuotaResponseDto(0);
-
-        //나중에는 이미지 생성 내역 테이블 불러와서 남은 횟수 반환(현재는 1개)
-        return new CheckAiImageQuotaResponseDto(1);
+        return new CheckAiImageQuotaResponseDto(3-usedToken);
     }
 
     @Override


### PR DESCRIPTION
### feat: 이미지 생성 가능 토큰수 수정

### 설명
- 이미지 생성 가능 토큰 수 1개 -> 3개로 수정
- 이미지 생성 내역을 관리하는 ImageGenerationHistory 테이블 추가
- 금일 날짜(이미지를 생성하는 일자)와 user_id에 해당하는 row값 계산 후 생성 가능한 토큰 수 반환
