### PR TITLE
Fix/product image relationship

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/global/exception/ErrorCode.java
+++ b/src/main/java/com/kakaotech/ott/ott/global/exception/ErrorCode.java
@@ -72,6 +72,7 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "이미지 처리 중 오류가 발생했습니다."),
     DUPLICATE_PRODUCT_NAME(HttpStatus.CONFLICT, "이미 존재하는 상품명입니다."),
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
+    VARIANT_NOT_FOUND(HttpStatus.NOT_FOUND, "품목을 찾을 수 없습니다."),
     INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
     INVALID_PRODUCT_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 상품 상태입니다."),
     INVALID_DISCOUNT(HttpStatus.BAD_REQUEST, "할인가는 정가보다 클 수 없습니다."),

--- a/src/main/java/com/kakaotech/ott/ott/global/exception/ErrorCode.java
+++ b/src/main/java/com/kakaotech/ott/ott/global/exception/ErrorCode.java
@@ -69,6 +69,7 @@ public enum ErrorCode {
     ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 주문내역입니다."),
 
     // product
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "이미지 처리 중 오류가 발생했습니다."),
     DUPLICATE_PRODUCT_NAME(HttpStatus.CONFLICT, "이미 존재하는 상품명입니다."),
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
     INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "재고가 부족합니다."),

--- a/src/main/java/com/kakaotech/ott/ott/product/domain/model/Product.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/domain/model/Product.java
@@ -28,9 +28,6 @@ public class Product {
     @Builder.Default
     private List<ProductVariant> variants = new ArrayList<>();
 
-    @Builder.Default
-    private List<ProductImage> images = new ArrayList<>();
-
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -111,15 +108,5 @@ public class Product {
     // 품목 추가
     public void addVariant(ProductVariant variant) {
         this.variants.add(variant);
-    }
-
-    // 이미지 추가
-    public void addImage(ProductImage image) {
-        this.images.add(image);
-    }
-
-    // 모든 이미지 제거
-    public void clearImages() {
-        this.images.clear();
     }
 }

--- a/src/main/java/com/kakaotech/ott/ott/product/domain/model/ProductImage.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/domain/model/ProductImage.java
@@ -8,13 +8,13 @@ import lombok.Getter;
 public class ProductImage {
 
     private Long id;
-    private Long productId;
+    private Long variantId;
     private int sequence;
     private String imageUuid;
 
     // 이미지 생성 팩토리 메서드
     public static ProductImage createImage(
-            Long productId,
+            Long variantId,
             int sequence,
             String imageUuid) {
 
@@ -23,7 +23,7 @@ public class ProductImage {
         validateImageUuid(imageUuid);
 
         return ProductImage.builder()
-                .productId(productId)
+                .variantId(variantId)
                 .sequence(sequence)
                 .imageUuid(imageUuid)
                 .build();

--- a/src/main/java/com/kakaotech/ott/ott/product/domain/model/ProductVariant.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/domain/model/ProductVariant.java
@@ -27,6 +27,9 @@ public class ProductVariant {
     @Builder.Default
     private List<ProductPromotion> promotions = new ArrayList<>();
 
+    @Builder.Default
+    private List<ProductImage> images = new ArrayList<>();
+
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -127,5 +130,15 @@ public class ProductVariant {
 
     public boolean isActive() {
         return this.status == VariantStatus.ACTIVE && this.availableQuantity > 0;
+    }
+
+    // 이미지 추가
+    public void addImage(ProductImage image) {
+        this.images.add(image);
+    }
+
+    // 모든 이미지 제거
+    public void clearImages() {
+        this.images.clear();
     }
 }

--- a/src/main/java/com/kakaotech/ott/ott/product/domain/repository/ProductImageJpaRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/domain/repository/ProductImageJpaRepository.java
@@ -12,19 +12,19 @@ import java.util.Optional;
 
 public interface ProductImageJpaRepository extends JpaRepository<ProductImageEntity, Long> {
 
-    // 상품별 이미지 조회 (시퀀스 순)
-    List<ProductImageEntity> findByProductEntityIdOrderBySequence(Long productId);
+    // 품목별 이미지 조회 (시퀀스 순)
+    List<ProductImageEntity> findByVariantEntityIdOrderBySequence(Long variantId);
 
     // 상품별 이미지 삭제
     @Modifying
     @Transactional
-    void deleteByProductEntityId(Long productId);
+    void deleteByVariantEntityId(Long productId);
 
     // 상품별 이미지 개수 카운트
-    int countByProductEntityId(Long productId);
+    int countByVariantEntityId(Long productId);
 
     // 메인 이미지 조회 (sequence = 1)
-    @Query("SELECT i FROM ProductImageEntity i WHERE i.productEntity = :productId AND i.sequence = 1")
+    @Query("SELECT i FROM ProductImageEntity i WHERE i.variantEntity = :productId AND i.sequence = 1")
     Optional<ProductImageEntity> findMainImage(@Param("productId") Long productId);
 
     // 시퀀스 업데이트

--- a/src/main/java/com/kakaotech/ott/ott/product/domain/repository/ProductImageRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/domain/repository/ProductImageRepository.java
@@ -10,24 +10,24 @@ public interface ProductImageRepository {
     // 기본 CRUD
     ProductImage save(ProductImage image);
 
-    Optional<ProductImage> findById(Long imageId);
+    ProductImage findById(Long imageId);
 
     void delete(Long imageId);
 
-    // 상품별 이미지 조회
-    List<ProductImage> findByProductId(Long productId);
+    // 품목별 이미지 조회
+    List<ProductImage> findByVariantId(Long variantId);
 
-    List<ProductImage> findByProductIdOrderBySequence(Long productId);
+    List<ProductImage> findByVariantIdOrderBySequence(Long variantId);
 
     // 비즈니스 메서드들
-    void deleteByProductId(Long productId);
+    void deleteByVariantId(Long variantId);
 //
-    int countByProductId(Long productId);
+    int countByVariantId(Long variantId);
 
-    Optional<ProductImage> findMainImage(Long productId);
+    Optional<ProductImage> findMainImage(Long variantId);
 
     // 시퀀스 관리
     void updateSequence(Long imageId, int sequence);
 
-    void reorderSequences(Long productId, List<Long> imageIds);
+    void reorderSequences(Long variantId, List<Long> imageIds);
 }

--- a/src/main/java/com/kakaotech/ott/ott/product/domain/repository/ProductJpaRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/domain/repository/ProductJpaRepository.java
@@ -1,5 +1,6 @@
 package com.kakaotech.ott.ott.product.domain.repository;
 
+import com.kakaotech.ott.ott.product.domain.model.Product;
 import com.kakaotech.ott.ott.product.infrastructure.entity.ProductEntity;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -10,8 +11,9 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
-public interface    ProductJpaRepository extends JpaRepository<ProductEntity, Long> {
+public interface ProductJpaRepository extends JpaRepository<ProductEntity, Long> {
 
     // 상품명 중복 체크
     boolean existsByName(String name);

--- a/src/main/java/com/kakaotech/ott/ott/product/domain/repository/ProductVariantRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/domain/repository/ProductVariantRepository.java
@@ -11,7 +11,7 @@ public interface ProductVariantRepository {
     // 기본 CRUD
     ProductVariant save(ProductVariant variant);
 
-    Optional<ProductVariant> findById(Long variantId);
+    ProductVariant findById(Long variantId);
 
     ProductVariant update(ProductVariant variant);
 

--- a/src/main/java/com/kakaotech/ott/ott/product/infrastructure/entity/ProductEntity.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/infrastructure/entity/ProductEntity.java
@@ -57,10 +57,6 @@ public class ProductEntity extends AuditEntity {
     @OneToMany(mappedBy = "productEntity", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProductVariantEntity> variants = new ArrayList<>();
 
-    @Builder.Default
-    @OneToMany(mappedBy = "productEntity", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ProductImageEntity> images = new ArrayList<>();
-
     // Domain → Entity 변환
     public static ProductEntity from(Product product) {
         ProductEntity entity = ProductEntity.builder()
@@ -81,14 +77,6 @@ public class ProductEntity extends AuditEntity {
             }
         }
 
-        // 이미지들 매핑
-        if (product.getImages() != null && !product.getImages().isEmpty()) {
-            for (ProductImage image : product.getImages()) {
-                ProductImageEntity imageEntity = ProductImageEntity.from(image, entity);
-                entity.getImages().add(imageEntity);
-            }
-        }
-
         return entity;
     }
 
@@ -105,9 +93,6 @@ public class ProductEntity extends AuditEntity {
                 .scrapCount(this.scrapCount)
                 .variants(this.variants != null
                         ? this.variants.stream().map(ProductVariantEntity::toDomain).collect(Collectors.toList())
-                        : List.of())
-                .images(this.images != null
-                        ? this.images.stream().map(ProductImageEntity::toDomain).collect(Collectors.toList())
                         : List.of())
                 .createdAt(this.getCreatedAt())
                 .updatedAt(this.getUpdatedAt())

--- a/src/main/java/com/kakaotech/ott/ott/product/infrastructure/entity/ProductImageEntity.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/infrastructure/entity/ProductImageEntity.java
@@ -19,8 +19,8 @@ public class ProductImageEntity {
 
     // 상품과의 관계 (N:1)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "product_id", nullable = false)
-    private ProductEntity productEntity;
+    @JoinColumn(name = "variant_id", nullable = false)
+    private ProductVariantEntity variantEntity;
 
     @Column(name = "sequence", nullable = false)
     private int sequence;
@@ -29,10 +29,10 @@ public class ProductImageEntity {
     private String imageUuid;
 
     // Domain → Entity 변환
-    public static ProductImageEntity from(ProductImage image, ProductEntity productEntity) {
+    public static ProductImageEntity from(ProductImage image, ProductVariantEntity productVariantEntity) {
         return ProductImageEntity.builder()
                 .id(image.getId())
-                .productEntity(productEntity)
+                .variantEntity(productVariantEntity)
                 .sequence(image.getSequence())
                 .imageUuid(image.getImageUuid())
                 .build();
@@ -42,7 +42,7 @@ public class ProductImageEntity {
     public ProductImage toDomain() {
         return ProductImage.builder()
                 .id(this.id)
-                .productId(this.productEntity.getId())
+                .variantId(this.variantEntity.getId())
                 .sequence(this.sequence)
                 .imageUuid(this.imageUuid)
                 .build();

--- a/src/main/java/com/kakaotech/ott/ott/product/infrastructure/entity/ProductVariantEntity.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/infrastructure/entity/ProductVariantEntity.java
@@ -1,5 +1,6 @@
 package com.kakaotech.ott.ott.product.infrastructure.entity;
 
+import com.kakaotech.ott.ott.product.domain.model.ProductImage;
 import com.kakaotech.ott.ott.product.domain.model.ProductPromotion;
 import com.kakaotech.ott.ott.product.domain.model.ProductVariant;
 import com.kakaotech.ott.ott.product.domain.model.VariantStatus;
@@ -50,6 +51,10 @@ public class ProductVariantEntity extends AuditEntity {
     @Column(name = "is_on_promotion", nullable = false)
     private boolean isOnPromotion;
 
+    @Builder.Default
+    @OneToMany(mappedBy = "variantEntity", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProductImageEntity> images = new ArrayList<>();
+
     // 특가와의 관계 (1:N)
     @Builder.Default
     @OneToMany(mappedBy = "variantEntity", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -68,7 +73,15 @@ public class ProductVariantEntity extends AuditEntity {
                 .isOnPromotion(variant.isOnPromotion())
                 .build();
 
-        // 특가들 매핑
+        // 이미지들 매핑
+        if (variant.getImages() != null && !variant.getImages().isEmpty()) {
+            for (ProductImage image : variant.getImages()) {
+                ProductImageEntity imageEntity = ProductImageEntity.from(image, entity);
+                entity.getImages().add(imageEntity);
+            }
+        }
+
+            // 특가들 매핑
         if (variant.getPromotions() != null && !variant.getPromotions().isEmpty()) {
             for (ProductPromotion promotion : variant.getPromotions()) {
                 ProductPromotionEntity promotionEntity = ProductPromotionEntity.from(promotion, entity);
@@ -90,6 +103,9 @@ public class ProductVariantEntity extends AuditEntity {
                 .availableQuantity(this.availableQuantity)
                 .reservedQuantity(this.reservedQuantity)
                 .isOnPromotion(this.isOnPromotion)
+                .images(this.images != null
+                        ? this.images.stream().map(ProductImageEntity::toDomain).collect(Collectors.toList())
+                        : List.of())
                 .promotions(this.promotions != null
                         ? this.promotions.stream().map(ProductPromotionEntity::toDomain).collect(Collectors.toList())
                         : List.of())

--- a/src/main/java/com/kakaotech/ott/ott/product/infrastructure/repositoryImpl/ProductImageRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/infrastructure/repositoryImpl/ProductImageRepositoryImpl.java
@@ -3,11 +3,10 @@ package com.kakaotech.ott.ott.product.infrastructure.repositoryImpl;
 import com.kakaotech.ott.ott.global.exception.CustomException;
 import com.kakaotech.ott.ott.global.exception.ErrorCode;
 import com.kakaotech.ott.ott.product.domain.model.ProductImage;
-import com.kakaotech.ott.ott.product.domain.repository.ProductImageJpaRepository;
-import com.kakaotech.ott.ott.product.domain.repository.ProductImageRepository;
-import com.kakaotech.ott.ott.product.domain.repository.ProductJpaRepository;
+import com.kakaotech.ott.ott.product.domain.repository.*;
 import com.kakaotech.ott.ott.product.infrastructure.entity.ProductEntity;
 import com.kakaotech.ott.ott.product.infrastructure.entity.ProductImageEntity;
+import com.kakaotech.ott.ott.product.infrastructure.entity.ProductVariantEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,22 +20,22 @@ import java.util.stream.Collectors;
 public class ProductImageRepositoryImpl implements ProductImageRepository {
 
     private final ProductImageJpaRepository productImageJpaRepository;
-    private final ProductJpaRepository productJpaRepository;
+    private final ProductVariantJpaRepository productVariantJpaRepository;
 
     @Override
     @Transactional
     public ProductImage save(ProductImage image) {
-        // 상품 존재 여부 확인
-        ProductEntity productEntity = productJpaRepository.findById(image.getProductId())
+        // 품목 존재 여부 확인
+        ProductVariantEntity productVariantEntity = productVariantJpaRepository.findById(image.getVariantId())
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
         // 최대 이미지 개수 체크 (5개 제한)
-        int currentImageCount = countByProductId(image.getProductId());
+        int currentImageCount = countByVariantId(image.getVariantId());
         if (image.getId() == null && currentImageCount >= 5) {
             throw new IllegalArgumentException("상품 이미지는 최대 5개까지만 등록 가능합니다.");
         }
 
-        ProductImageEntity entity = ProductImageEntity.from(image, productEntity);
+        ProductImageEntity entity = ProductImageEntity.from(image, productVariantEntity);
         ProductImageEntity savedEntity = productImageJpaRepository.save(entity);
 
         return savedEntity.toDomain();
@@ -44,9 +43,10 @@ public class ProductImageRepositoryImpl implements ProductImageRepository {
 
     @Override
     @Transactional(readOnly = true)
-    public Optional<ProductImage> findById(Long imageId) {
+    public ProductImage findById(Long imageId) {
         return productImageJpaRepository.findById(imageId)
-                .map(ProductImageEntity::toDomain);
+                .map(ProductImageEntity::toDomain)
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
     }
 
     @Override
@@ -60,8 +60,8 @@ public class ProductImageRepositoryImpl implements ProductImageRepository {
 
     @Override
     @Transactional(readOnly = true)
-    public List<ProductImage> findByProductId(Long productId) {
-        return productImageJpaRepository.findByProductEntityIdOrderBySequence(productId)
+    public List<ProductImage> findByVariantId(Long variantId) {
+        return productImageJpaRepository.findByVariantEntityIdOrderBySequence(variantId)
                 .stream()
                 .map(ProductImageEntity::toDomain)
                 .collect(Collectors.toList());
@@ -69,8 +69,8 @@ public class ProductImageRepositoryImpl implements ProductImageRepository {
 
     @Override
     @Transactional(readOnly = true)
-    public List<ProductImage> findByProductIdOrderBySequence(Long productId) {
-        return productImageJpaRepository.findByProductEntityIdOrderBySequence(productId)
+    public List<ProductImage> findByVariantIdOrderBySequence(Long variantId) {
+        return productImageJpaRepository.findByVariantEntityIdOrderBySequence(variantId)
                 .stream()
                 .map(ProductImageEntity::toDomain)
                 .collect(Collectors.toList());
@@ -78,20 +78,20 @@ public class ProductImageRepositoryImpl implements ProductImageRepository {
 
     @Override
     @Transactional
-    public void deleteByProductId(Long productId) {
-        productImageJpaRepository.deleteByProductEntityId(productId);
+    public void deleteByVariantId(Long variantId) {
+        productImageJpaRepository.deleteByVariantEntityId(variantId);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public int countByProductId(Long productId) {
-        return productImageJpaRepository.countByProductEntityId(productId);
+    public int countByVariantId(Long variantId) {
+        return productImageJpaRepository.countByVariantEntityId(variantId);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Optional<ProductImage> findMainImage(Long productId) {
-        return productImageJpaRepository.findMainImage(productId)
+    public Optional<ProductImage> findMainImage(Long variantId) {
+        return productImageJpaRepository.findMainImage(variantId)
                 .map(ProductImageEntity::toDomain);
     }
 
@@ -112,12 +112,12 @@ public class ProductImageRepositoryImpl implements ProductImageRepository {
     @Override
     @Transactional
     public void reorderSequences(Long productId, List<Long> imageIds) {
-        // 상품 존재 여부 확인
-        productJpaRepository.findById(productId)
+        // 품목 존재 여부 확인
+        productVariantJpaRepository.findById(productId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND)); // 적절한 에러코드로 변경 필요
 
         // 이미지 ID들이 해당 상품에 속하는지 확인
-        List<ProductImageEntity> existingImages = productImageJpaRepository.findByProductEntityIdOrderBySequence(productId);
+        List<ProductImageEntity> existingImages = productImageJpaRepository.findByVariantEntityIdOrderBySequence(productId);
         List<Long> existingImageIds = existingImages.stream()
                 .map(ProductImageEntity::getId)
                 .collect(Collectors.toList());

--- a/src/main/java/com/kakaotech/ott/ott/product/infrastructure/repositoryImpl/ProductVariantRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/infrastructure/repositoryImpl/ProductVariantRepositoryImpl.java
@@ -43,9 +43,10 @@ public class ProductVariantRepositoryImpl implements ProductVariantRepository {
 
     @Override
     @Transactional(readOnly = true)
-    public Optional<ProductVariant> findById(Long variantId) {
+    public ProductVariant findById(Long variantId) {
         return productVariantJpaRepository.findById(variantId)
-                .map(ProductVariantEntity::toDomain);
+                .map(ProductVariantEntity::toDomain)
+                .orElseThrow(() -> new CustomException(ErrorCode.VARIANT_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/com/kakaotech/ott/ott/product/presentation/dto/request/ProductCreateRequestDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/presentation/dto/request/ProductCreateRequestDto.java
@@ -27,9 +27,7 @@ public class ProductCreateRequestDto {
     @Valid
     private List<VariantDto> variants;
 
-    @NotNull(message = "이미지 정보는 필수입니다")
-    @Size(max = 5, message = "이미지는 최대 5개까지 업로드할 수 있습니다.")
-    private List<MultipartFile> images;
+    private Map<Integer, List<MultipartFile>> variantImagesMap;
 
     @Getter
     @Builder

--- a/src/main/java/com/kakaotech/ott/ott/product/presentation/dto/response/ProductGetResponseDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/presentation/dto/response/ProductGetResponseDto.java
@@ -33,9 +33,6 @@ public class ProductGetResponseDto {
     @JsonProperty("variants")
     private List<VariantResponse> variants;
 
-    @JsonProperty("image_urls")
-    private List<String> imageUrls;
-
     @JsonProperty("scraped")
     private Boolean scraped;
 
@@ -59,6 +56,9 @@ public class ProductGetResponseDto {
 
         @JsonProperty("reserved_quantity")
         private int reservedQuantity;
+
+        @JsonProperty("image_urls")
+        private List<String> imageUrls;
 
         @JsonProperty("promotions")
         private List<PromotionResponse> promotions;

--- a/src/main/java/com/kakaotech/ott/ott/user/application/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/user/application/serviceImpl/UserServiceImpl.java
@@ -15,7 +15,9 @@ import com.kakaotech.ott.ott.post.domain.repository.PostRepository;
 import com.kakaotech.ott.ott.post.presentation.dto.response.PostAllResponseDto;
 import com.kakaotech.ott.ott.post.presentation.dto.response.PostAuthorResponseDto;
 import com.kakaotech.ott.ott.product.domain.model.Product;
+import com.kakaotech.ott.ott.product.domain.model.ProductVariant;
 import com.kakaotech.ott.ott.product.domain.repository.ProductRepository;
+import com.kakaotech.ott.ott.product.domain.repository.ProductVariantRepository;
 import com.kakaotech.ott.ott.recommendProduct.domain.model.DeskProduct;
 import com.kakaotech.ott.ott.recommendProduct.domain.repository.DeskProductRepository;
 import com.kakaotech.ott.ott.scrap.domain.model.Scrap;
@@ -52,7 +54,7 @@ public class UserServiceImpl implements UserService {
     private final ScrapRepository scrapRepository;
     private final DeskProductRepository deskProductRepository;
     private final PointHistoryRepository pointHistoryRepository;
-    private final ProductRepository productRepository;
+    private final ProductVariantRepository productVariantRepository;
 
     @Value("${verified.code}")
     private String verifiedCode;
@@ -199,8 +201,8 @@ public class UserServiceImpl implements UserService {
                         DeskProduct deskProduct = deskProductRepository.findById(scrap.getTargetId());
                         thumbnailImage = deskProduct.getImagePath();
                     } else {
-                        Product product = productRepository.findById(scrap.getTargetId());
-                        thumbnailImage = product.getImages().get(0).getImageUuid();
+                        ProductVariant productVariant = productVariantRepository.findById(scrap.getTargetId());
+                        thumbnailImage = productVariant.getImages().get(0).getImageUuid();
                     }
 
 


### PR DESCRIPTION
## ✏️ PR 내용
### fix: product -> product_variant로 image 테이블의 부모 변경

### 설명
> 설명: 변경 동기와 내용(무엇을, 어떻게)을 상세히 기술합니다.

이번 PR은 상품 정보 scrap시 각 품목마다 썸네일 정보를 가져오기 위해, image 테이블의 부모 관계를 `product`에서 `product_variant`테이블로 변경했습니다.
- model, entity 구조 변경
- repository 접근 코드 변경
- scarp 썸네일 조회 코드 변경