### PR TITLE
feat: 나의 데스크 조회에서 상세 페이지 이동 추가

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/aiImage/application/service/AiImageService.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/application/service/AiImageService.java
@@ -1,6 +1,7 @@
 package com.kakaotech.ott.ott.aiImage.application.service;
 
 import com.kakaotech.ott.ott.aiImage.domain.model.AiImage;
+import com.kakaotech.ott.ott.aiImage.domain.model.AiImageConcept;
 import com.kakaotech.ott.ott.aiImage.presentation.dto.request.AiImageAndProductRequestDto;
 import com.kakaotech.ott.ott.aiImage.presentation.dto.response.AiImageAndProductResponseDto;
 import com.kakaotech.ott.ott.aiImage.presentation.dto.response.AiImageSaveResponseDto;
@@ -10,7 +11,7 @@ import java.io.IOException;
 
 public interface AiImageService {
 
-    AiImageSaveResponseDto handleImageValidation(MultipartFile image, Long userId) throws IOException;
+    AiImageSaveResponseDto handleImageValidation(MultipartFile image, AiImageConcept concept, Long userId) throws IOException;
 
     AiImage insertAiImage(AiImageAndProductRequestDto aiImageAndProductRequestDto);
 

--- a/src/main/java/com/kakaotech/ott/ott/aiImage/application/serviceImpl/AiImageServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/application/serviceImpl/AiImageServiceImpl.java
@@ -3,6 +3,7 @@ package com.kakaotech.ott.ott.aiImage.application.serviceImpl;
 import com.kakaotech.ott.ott.aiImage.application.service.FastApiClient;
 import com.kakaotech.ott.ott.aiImage.application.service.ImageUploader;
 import com.kakaotech.ott.ott.aiImage.domain.model.AiImage;
+import com.kakaotech.ott.ott.aiImage.domain.model.AiImageConcept;
 import com.kakaotech.ott.ott.aiImage.domain.model.AiImageState;
 import com.kakaotech.ott.ott.global.exception.CustomException;
 import com.kakaotech.ott.ott.global.exception.ErrorCode;
@@ -42,12 +43,12 @@ public class AiImageServiceImpl implements AiImageService {
 
     @Override
     @Transactional
-    public AiImageSaveResponseDto handleImageValidation(MultipartFile image, Long userId) throws IOException {
+    public AiImageSaveResponseDto handleImageValidation(MultipartFile image, AiImageConcept concept, Long userId) throws IOException {
         // 1. 이미지 업로드 (S3에 저장 후 퍼블릭 URL 반환)
         String imageUrl = imageUploader.upload(image);
 
         // 2. FastAPI로 전송하여 이미지 유효성 검사
-        FastApiRequestDto request = new FastApiRequestDto(imageUrl);
+        FastApiRequestDto request = new FastApiRequestDto(imageUrl, concept);
         FastApiResponseDto response = fastApiClient.sendBeforeImageToFastApi(request);
 
         System.out.println("fastApi 결과 : " + response.isClassify());
@@ -58,7 +59,7 @@ public class AiImageServiceImpl implements AiImageService {
             throw new CustomException(ErrorCode.INVALID_IMAGE);
         }
 
-        AiImage aiImage = AiImage.createAiImage(userId, response.getInitialImageUrl());
+        AiImage aiImage = AiImage.createAiImage(userId, concept, response.getInitialImageUrl());
         AiImage savedAiImage = aiImageRepository.saveImage(aiImage);
 
         return new AiImageSaveResponseDto(savedAiImage.getId());
@@ -100,7 +101,7 @@ public class AiImageServiceImpl implements AiImageService {
             throw new CustomException(ErrorCode.USER_FORBIDDEN);
         }
 
-        AiImageResponseDto aiImageResponseDto = new AiImageResponseDto(aiImage.getId(), aiImage.getState(), aiImage.getBeforeImagePath(), aiImage.getAfterImagePath(), aiImage.getCreatedAt());
+        AiImageResponseDto aiImageResponseDto = new AiImageResponseDto(aiImage.getId(), aiImage.getPostId(), aiImage.getState(), aiImage.getBeforeImagePath(), aiImage.getAfterImagePath(), aiImage.getCreatedAt());
 
         if(aiImage.getState().equals(AiImageState.FAILED) || aiImage.getState().equals(AiImageState.PENDING)) {
             return new AiImageAndProductResponseDto(aiImageResponseDto, null);

--- a/src/main/java/com/kakaotech/ott/ott/aiImage/domain/model/AiImageConcept.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/domain/model/AiImageConcept.java
@@ -1,0 +1,4 @@
+package com.kakaotech.ott.ott.aiImage.domain.model;
+
+public enum AiImageConcept {
+}

--- a/src/main/java/com/kakaotech/ott/ott/aiImage/presentation/dto/response/AiImageResponseDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/presentation/dto/response/AiImageResponseDto.java
@@ -16,6 +16,8 @@ public class AiImageResponseDto {
 
     private Long imageId;
 
+    private Long postId;
+
     private AiImageState state;
 
     private String beforeImagePath;

--- a/src/main/java/com/kakaotech/ott/ott/user/presentation/dto/response/MyDeskImageResponseDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/user/presentation/dto/response/MyDeskImageResponseDto.java
@@ -23,7 +23,7 @@ public class MyDeskImageResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ImageDto {
-        private Long aiImageId;
+            private Long aiImageId;
         private String beforeImagePath;
         private String afterImagePath;
         private LocalDateTime createdAt;


### PR DESCRIPTION

### feat: 나의 데스크 조회에서 상세 페이지 이동 추가

### 설명
- 기존 : 나의 데스크 조회 시 before + after 이미지 조회
- 수정 : after 또는 before 이미지 클릭 시 해당 이미지의 추천 상품 리스트 조회 페이지 이동
