### PR TITLE
feat: AI 이미지 생성 시 사용자가 컨셉 선택 추가

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/aiImage/application/serviceImpl/FastApiClientImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/application/serviceImpl/FastApiClientImpl.java
@@ -32,8 +32,6 @@ public class FastApiClientImpl implements FastApiClient {
 
         fastApiRequestDto.fastApiUrl(baseUrl);
 
-        System.out.println(fastApiRequestDto.getInitialImageUrl());
-
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
 

--- a/src/main/java/com/kakaotech/ott/ott/aiImage/domain/model/AiImage.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/domain/model/AiImage.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 @Getter
+@Builder
 public class AiImage {
 
     private Long id;
@@ -13,6 +14,8 @@ public class AiImage {
     private Long userId;
 
     private Long postId;
+
+    private AiImageConcept concept;
 
     private AiImageState state;
 
@@ -22,22 +25,12 @@ public class AiImage {
 
     private LocalDateTime createdAt;
 
-    @Builder
-    public AiImage(Long id, Long userId, Long postId, AiImageState state, String beforeImagePath, String afterImagePath, LocalDateTime createdAt) {
-        this.id = id;
-        this.userId = userId;
-        this.postId = postId;
-        this.state = state;
-        this.beforeImagePath = beforeImagePath;
-        this.afterImagePath = afterImagePath;
-        this.createdAt = createdAt;
-    }
-
-    public static AiImage createAiImage(Long userId, String beforeImagePath) {
+    public static AiImage createAiImage(Long userId, AiImageConcept concept, String beforeImagePath) {
 
         return AiImage.builder()
                 .userId(userId)
                 .postId(null)
+                .concept(concept)
                 .state(AiImageState.PENDING)
                 .beforeImagePath(beforeImagePath)
                 .afterImagePath(null)

--- a/src/main/java/com/kakaotech/ott/ott/aiImage/domain/model/AiImageConcept.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/domain/model/AiImageConcept.java
@@ -1,4 +1,5 @@
 package com.kakaotech.ott.ott.aiImage.domain.model;
 
 public enum AiImageConcept {
+    BASIC
 }

--- a/src/main/java/com/kakaotech/ott/ott/aiImage/infrastructure/entity/AiImageEntity.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/infrastructure/entity/AiImageEntity.java
@@ -1,6 +1,7 @@
 package com.kakaotech.ott.ott.aiImage.infrastructure.entity;
 
 import com.kakaotech.ott.ott.aiImage.domain.model.AiImage;
+import com.kakaotech.ott.ott.aiImage.domain.model.AiImageConcept;
 import com.kakaotech.ott.ott.aiImage.domain.model.AiImageState;
 import com.kakaotech.ott.ott.user.infrastructure.entity.UserEntity;
 import jakarta.persistence.*;
@@ -31,6 +32,9 @@ public class AiImageEntity {
     @Column(name = "post_id")
     private Long postId;
 
+    @Column(name = "concept")
+    private AiImageConcept concept;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "state", length = 30)
     private AiImageState state;
@@ -51,6 +55,7 @@ public class AiImageEntity {
                 .id(this.id)
                 .userId(this.userEntity.getId())
                 .postId(this.postId)
+                .concept(this.concept)
                 .state(this.state)
                 .beforeImagePath(this.beforeImagePath)
                 .afterImagePath(this.afterImagePath)
@@ -63,6 +68,7 @@ public class AiImageEntity {
         return AiImageEntity.builder()
                 .userEntity(userEntity)
                 .postId(aiImage.getPostId())
+                .concept(aiImage.getConcept())
                 .state(aiImage.getState())
                 .beforeImagePath(aiImage.getBeforeImagePath())
                 .afterImagePath(aiImage.getAfterImagePath())

--- a/src/main/java/com/kakaotech/ott/ott/aiImage/presentation/controller/AiImageController.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/presentation/controller/AiImageController.java
@@ -69,7 +69,7 @@ public class AiImageController {
                     .body(ApiResponse.error(400, "이미지 파일이 비어있습니다."));
         }
 
-        AiImageSaveResponseDto aiImageSaveResponseDto = aiImageService.handleImageValidation(image, userId);
+        AiImageSaveResponseDto aiImageSaveResponseDto = aiImageService.handleImageValidation(image, requestDto.getConcept(), userId);
 
         return ResponseEntity.ok(ApiResponse.success("AI 이미지 생성 요청이 접수되었습니다.", aiImageSaveResponseDto));
     }

--- a/src/main/java/com/kakaotech/ott/ott/aiImage/presentation/dto/request/AiImageUploadRequestDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/presentation/dto/request/AiImageUploadRequestDto.java
@@ -1,6 +1,8 @@
 package com.kakaotech.ott.ott.aiImage.presentation.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kakaotech.ott.ott.aiImage.domain.model.AiImageConcept;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
@@ -13,5 +15,9 @@ public class AiImageUploadRequestDto {
     @NotNull(message = "이미지는 필수 항목입니다.")
     @JsonProperty("before_image_path")
     private MultipartFile beforeImagePath;
+
+    @NotBlank(message = "컨셉은 필수입니다.")
+    @JsonProperty("concept")
+    private AiImageConcept concept;
 
 }

--- a/src/main/java/com/kakaotech/ott/ott/aiImage/presentation/dto/request/FastApiRequestDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/presentation/dto/request/FastApiRequestDto.java
@@ -1,6 +1,7 @@
 package com.kakaotech.ott.ott.aiImage.presentation.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kakaotech.ott.ott.aiImage.domain.model.AiImageConcept;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,8 +16,8 @@ public class FastApiRequestDto {
     @JsonProperty("initial_image_url")
     private String initialImageUrl;
 
-//    @JsonProperty("user_id")
-//    private Long user_id;
+    @JsonProperty("concept")
+    private AiImageConcept concept;
 
     public void fastApiUrl(String domain) {
         this.initialImageUrl = domain + this.initialImageUrl;


### PR DESCRIPTION

### feat: AI 이미지 생성 시 사용자가 컨셉 선택 추가

### 설명
- 기존 : 사용자가 아닌 서버가 데스크 이미지 생성 컨셉 지정
- 수정 : 사용자가 이미지 생성 전 원하는 컨셉을 같이 전송
