### PR TITLE
feat: OrderItems 특가 상태, 정상가, 할인금액, 최종가 추가 및 분리 후 Dto 변경

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/orderItem/domain/model/OrderItem.java
+++ b/src/main/java/com/kakaotech/ott/ott/orderItem/domain/model/OrderItem.java
@@ -15,13 +15,19 @@ public class OrderItem {
 
     private Long orderId;
 
-    private Long productId;
+    private Long variantsId;
+
+    private Long promotionId;
 
     private OrderItemStatus status;
 
-    private int price;
+    private int originalPrice;
 
     private int quantity;
+
+    private int discountAmount;
+
+    private int finalPrice;
 
     private OrderItemStatus pendingProductStatus;
 
@@ -33,14 +39,17 @@ public class OrderItem {
 
     private LocalDateTime refundedAt;
 
-    public static OrderItem createOrderItem(Long orderId, Long productId, int price, int quantity) {
+    public static OrderItem createOrderItem(Long orderId, Long variantsId, Long promotionId, int originalPrice, int quantity, int discountAmount, int finalPrice) {
 
         return OrderItem.builder()
                 .orderId(orderId)
-                .productId(productId)
+                .variantsId(variantsId)
+                .promotionId(promotionId)
                 .status(OrderItemStatus.PENDING)
-                .price(price)
+                .originalPrice(originalPrice)
                 .quantity(quantity)
+                .discountAmount(discountAmount)
+                .finalPrice(finalPrice)
                 .pendingProductStatus(OrderItemStatus.PENDING)
                 .build();
     }
@@ -69,7 +78,7 @@ public class OrderItem {
         if (this.status != OrderItemStatus.PAID) throw new CustomException(ErrorCode.NOT_CANCELABLE_STATE);
 
         this.status = OrderItemStatus.CANCELED;
-        this.refundAmount = this.getPrice() * this.getQuantity();
+        this.refundAmount = this.finalPrice * this.getQuantity();
         this.refundReason = refundReason;
         this.canceledAt = canceledAt;
     }
@@ -78,7 +87,7 @@ public class OrderItem {
         if (this.status != OrderItemStatus.DELIVERED) throw new CustomException(ErrorCode.NOT_REFUNDABLE_STATE);
 
         this.status = OrderItemStatus.REFUND;
-        this.refundAmount = this.getPrice() * this.getQuantity();
+        this.refundAmount = this.finalPrice * this.getQuantity();
         this.refundReason = refundReason;
         this.refundedAt = refundedAt;
     }
@@ -86,7 +95,7 @@ public class OrderItem {
     public void confirm() {
         if (this.status != OrderItemStatus.DELIVERED) throw new CustomException(ErrorCode.NOT_CONFIRMABLE_STATE);
 
-        this.status = OrderItemStatus.CONFIRM;
+        this.status = OrderItemStatus.CONFIRMED;
     }
 
 }

--- a/src/main/java/com/kakaotech/ott/ott/orderItem/domain/model/OrderItemStatus.java
+++ b/src/main/java/com/kakaotech/ott/ott/orderItem/domain/model/OrderItemStatus.java
@@ -6,5 +6,5 @@ public enum OrderItemStatus {
     DELIVERED,
     REFUND,
     CANCELED,
-    CONFIRM
+    CONFIRMED
 }

--- a/src/main/java/com/kakaotech/ott/ott/orderItem/domain/repository/OrderItemJpaRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/orderItem/domain/repository/OrderItemJpaRepository.java
@@ -8,7 +8,11 @@ import java.util.List;
 import java.util.Optional;
 
 public interface OrderItemJpaRepository extends JpaRepository<OrderItemEntity, Long> {
-    boolean existsByProductIdAndPendingProductStatus(Long productId, OrderItemStatus status);
 
+    boolean existsByProductVariantEntityIdAndPendingProductStatusAndStatus(
+            Long variantsId,
+            OrderItemStatus pendingStatus,
+            OrderItemStatus excludedStatus
+    );
     List<OrderItemEntity> findByProductOrderEntity_Id(Long productOrderId);
 }

--- a/src/main/java/com/kakaotech/ott/ott/orderItem/domain/repository/OrderItemRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/orderItem/domain/repository/OrderItemRepository.java
@@ -9,7 +9,7 @@ public interface OrderItemRepository {
 
     OrderItem save(OrderItem orderItem);
 
-    void existsByProductIdAndPendingProductStatus(Long productId, OrderItemStatus orderItemStatus);
+    void existsByProductIdAndPendingProductStatus(Long productId, OrderItemStatus orderItemStatusPending, OrderItemStatus orderItemStatusCanceled);
 
     List<OrderItem> findByProductOrderId(Long productOrderId);
 

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/presentation/dto/request/ServiceProductDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/presentation/dto/request/ServiceProductDto.java
@@ -16,9 +16,15 @@ public class ServiceProductDto {
     private Long productId;
 
     @NotNull
-    private int price;
+    private Long promotionId;
+
+    @NotNull
+    private int originalPrice;
 
     @NotNull
     private int quantity;
+
+    @NotNull
+    private int discountPrice;
 
 }

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/presentation/dto/response/MyProductOrderResponseDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/presentation/dto/response/MyProductOrderResponseDto.java
@@ -59,6 +59,7 @@ public class MyProductOrderResponseDto {
     @AllArgsConstructor
     public static class PaymentInfo {
         private String paymentMethod;   // TODO: 타입 ENUM으로 바꿔야됨
+        private int originalAmount;
         private int paymentAmount;
         private int discountAmount;
     }


### PR DESCRIPTION

### feat: OrderItems 특가 상태, 정상가, 할인금액, 최종가 추가 및 분리 후 Dto 변경

### 설명
- 기존 OrderItem 에서 어떤 특가 상태로 구매한 것인지 확인 불가능
- promotion_id를 주입 받아 어떤 특가 상태에서 구매했는지 확인
- 기존 상품가, 할인금액으로만 관리하여 최종 가에 대해서 추가적인 계산 필요
- 정상가, 할인 금액, 최종가를 분리하여  명시적인 가격 상태 관리
- 컬럼이 바뀜에 따라 응답 dto 변경