### PR TITLE
feat: DeskProduct와 AiImage 테이블 사이 관계 테이블 추가

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/aiImage/presentation/controller/AiImageController.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/presentation/controller/AiImageController.java
@@ -80,15 +80,7 @@ public class AiImageController {
 
         AiImage aiImage = aiImageService.insertAiImage(requestDto);
 
-        List<DeskProduct> deskProduct = productDomainService.createdProduct(
-                requestDto, aiImage, aiImage.getUserId());
-
-        // 예외 방지: 빈 리스트 처리
-        if (deskProduct == null || deskProduct.isEmpty()) {
-            return ResponseEntity.ok(ApiResponse.success("AI 이미지 저장에 실패했습니다.", null));
-        }
-
-        AiImageSaveResponseDto aiImageSaveResponseDto = new AiImageSaveResponseDto(deskProduct.get(0).getAiImageId());
+        AiImageSaveResponseDto aiImageSaveResponseDto =  productDomainService.createdProduct(requestDto, aiImage, aiImage.getUserId());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("AI 이미지 저장이 완료됐습니다.", aiImageSaveResponseDto));
     }

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/application/service/ProductDomainService.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/application/service/ProductDomainService.java
@@ -1,6 +1,7 @@
 package com.kakaotech.ott.ott.recommendProduct.application.service;
 
 import com.kakaotech.ott.ott.aiImage.domain.model.AiImage;
+import com.kakaotech.ott.ott.aiImage.presentation.dto.response.AiImageSaveResponseDto;
 import com.kakaotech.ott.ott.recommendProduct.domain.model.DeskProduct;
 import com.kakaotech.ott.ott.aiImage.presentation.dto.request.AiImageAndProductRequestDto;
 import com.kakaotech.ott.ott.recommendProduct.presentation.dto.response.RecommendedItemsDto;
@@ -9,7 +10,7 @@ import java.util.List;
 
 public interface ProductDomainService {
 
-    List<DeskProduct> createdProduct(AiImageAndProductRequestDto aiImageAndProductRequestDto, AiImage aiImage, Long userId);
+    AiImageSaveResponseDto createdProduct(AiImageAndProductRequestDto aiImageAndProductRequestDto, AiImage aiImage, Long userId);
 
     List<RecommendedItemsDto> getRecommendItems(Long userId);
 }

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/model/AiImageRecommendedProduct.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/model/AiImageRecommendedProduct.java
@@ -1,0 +1,28 @@
+package com.kakaotech.ott.ott.recommendProduct.domain.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AiImageRecommendedProduct {
+
+    private Long id;
+
+    private Long aiImageId;
+
+    private Long deskProductId;
+
+    private Integer centerX;
+    private Integer centerY;
+
+    public static AiImageRecommendedProduct createAiImageRecommendedProduct(Long aiImageId, Long deskProductId, Integer centerX, Integer centerY) {
+
+        return AiImageRecommendedProduct.builder()
+                .aiImageId(aiImageId)
+                .deskProductId(deskProductId)
+                .centerX(centerX)
+                .centerY(centerY)
+                .build();
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/model/DeskProduct.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/model/DeskProduct.java
@@ -4,12 +4,14 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class DeskProduct {
 
     private Long id;
 
     private Long subCategoryId;
-    private Long aiImageId;
+
+    private String productCode;
 
     private String name;
     private Integer price;
@@ -21,38 +23,15 @@ public class DeskProduct {
 
     private String purchaseUrl;
 
-    private Integer centerX;
-    private Integer centerY;
-
     private String imagePath;
 
-    @Builder
-    public DeskProduct(Long id, Long subCategoryId, Long aiImageId,
-                       String name, Integer price, String purchasePlace,
-                       Integer scrapCount, Integer clickCount, Integer weight,
-                       String purchaseUrl, Integer centerX, Integer centerY, String imagePath) {
-        this.id = id;
-        this.subCategoryId = subCategoryId;
-        this.aiImageId = aiImageId;
-        this.name = name;
-        this.price = price;
-        this.purchasePlace = purchasePlace;
-        this.scrapCount = scrapCount;
-        this.clickCount = clickCount;
-        this.weight = weight;
-        this.purchaseUrl = purchaseUrl;
-        this.centerX = centerX;
-        this.centerY = centerY;
-        this.imagePath = imagePath;
-    }
-
-    public static DeskProduct createDeskProduct(Long subCategoryId, Long aiImageId,
+    public static DeskProduct createDeskProduct(Long subCategoryId, String productCode,
                                                 String name, Integer price, String purchasePlace,
-                                                String purchaseUrl, Integer centerX, Integer centerY, String imagePath) {
+                                                String purchaseUrl, String imagePath) {
 
         return DeskProduct.builder()
                 .subCategoryId(subCategoryId)
-                .aiImageId(aiImageId)
+                .productCode(productCode)
                 .name(name)
                 .price(price)
                 .purchasePlace(purchasePlace)
@@ -60,8 +39,6 @@ public class DeskProduct {
                 .clickCount(0)
                 .weight(0)
                 .purchaseUrl(purchaseUrl)
-                .centerX(centerX)
-                .centerY(centerY)
                 .imagePath(imagePath)
                 .build();
     }

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/repository/AiImageRecommendedProductJpaRepsitory.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/repository/AiImageRecommendedProductJpaRepsitory.java
@@ -1,0 +1,13 @@
+package com.kakaotech.ott.ott.recommendProduct.domain.repository;
+
+import com.kakaotech.ott.ott.recommendProduct.infrastructure.entity.AiImageRecommendedProductEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AiImageRecommendedProductJpaRepsitory extends JpaRepository<AiImageRecommendedProductEntity, Long> {
+
+    List<AiImageRecommendedProductEntity> findByAiImageEntity_IdAndDeskProductEntity_id(Long aiImageId, Long deskProductId);
+
+    List<AiImageRecommendedProductEntity> findByAiImageEntity_Id(Long aiImageId);
+}

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/repository/AiImageRecommendedProductRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/repository/AiImageRecommendedProductRepository.java
@@ -1,0 +1,14 @@
+package com.kakaotech.ott.ott.recommendProduct.domain.repository;
+
+import com.kakaotech.ott.ott.recommendProduct.domain.model.AiImageRecommendedProduct;
+
+import java.util.List;
+
+public interface AiImageRecommendedProductRepository {
+
+    AiImageRecommendedProduct save(AiImageRecommendedProduct aiImageRecommendedProduct);
+
+    List<AiImageRecommendedProduct> findByAiImageIdAndDeskProductId(Long aiImageId, Long deskProductId);
+
+    List<AiImageRecommendedProduct> findByAiImageId(Long aiImageId);
+}

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/repository/DeskProductJpaRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/repository/DeskProductJpaRepository.java
@@ -12,8 +12,6 @@ import java.util.List;
 
 public interface DeskProductJpaRepository extends JpaRepository<DeskProductEntity, Long> {
 
-    List<DeskProductEntity> findByAiImageEntity_Id(Long aiImageId);
-
     // JPA에서 Pageable로 Top N 조회 (정렬 + 제한)
     @Query("SELECT d FROM DeskProductEntity d ORDER BY d.weight DESC")
     List<DeskProductEntity> findByOrderByWeightDesc(Pageable pageable);

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/repository/DeskProductRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/repository/DeskProductRepository.java
@@ -10,8 +10,6 @@ public interface DeskProductRepository {
 
     DeskProduct save(DeskProduct deskProduct, ProductSubCategoryEntity productSubCategoryEntity, AiImageEntity aiImageEntity);
 
-    List<DeskProduct> findByAiImageId(Long aiImageId);
-
     List<DeskProduct> findTop7ByWeight();
 
     void incrementScrapCount(Long postId, Long delta);

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/infrastructure/entity/AiImageRecommendedProductEntity.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/infrastructure/entity/AiImageRecommendedProductEntity.java
@@ -1,0 +1,54 @@
+package com.kakaotech.ott.ott.recommendProduct.infrastructure.entity;
+
+import com.kakaotech.ott.ott.aiImage.infrastructure.entity.AiImageEntity;
+import com.kakaotech.ott.ott.recommendProduct.domain.model.AiImageRecommendedProduct;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "ai_image_recommended_products")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+public class AiImageRecommendedProductEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ai_image_id", nullable = false)
+    private AiImageEntity aiImageEntity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "desk_product_id", nullable = false)
+    private DeskProductEntity deskProductEntity;
+
+    @Column(name = "center_x")
+    private Integer centerX;
+
+    @Column(name = "center_y")
+    private Integer centerY;
+
+    public static AiImageRecommendedProductEntity from(AiImageRecommendedProduct aiImageRecommendedProduct, AiImageEntity aiImageEntity, DeskProductEntity deskProductEntity) {
+
+        return AiImageRecommendedProductEntity.builder()
+                .aiImageEntity(aiImageEntity)
+                .deskProductEntity(deskProductEntity)
+                .centerX(aiImageRecommendedProduct.getCenterX())
+                .centerY(aiImageRecommendedProduct.getCenterY())
+                .build();
+    }
+
+    public AiImageRecommendedProduct toDomain() {
+
+        return AiImageRecommendedProduct.builder()
+                .id(this.getId())
+                .aiImageId(this.aiImageEntity.getId())
+                .deskProductId(this.deskProductEntity.getId())
+                .centerX(this.getCenterX())
+                .centerY(this.getCenterY())
+                .build();
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/infrastructure/entity/DeskProductEntity.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/infrastructure/entity/DeskProductEntity.java
@@ -21,9 +21,8 @@ public class DeskProductEntity {
     @JoinColumn(name = "sub_category_id") // FK 컬럼명
     private ProductSubCategoryEntity productSubCategoryEntity;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "ai_image_id") // FK 컬럼명
-    private AiImageEntity aiImageEntity;
+    @Column(name = "product_code", nullable = false)
+    private String productCode;
 
     @Column(name = "name", nullable = false, length = 255)
     private String name;
@@ -42,11 +41,6 @@ public class DeskProductEntity {
     @Column(name = "purchase_url", nullable = false, length = 255)
     private String purchaseUrl;
 
-    @Column(name = "center_x", nullable = false)
-    private Integer centerX;
-    @Column(name = "center_y", nullable = false)
-    private Integer centerY;
-
     @Column(name = "image_path", nullable = false, length = 255)
     private String imagePath;
 
@@ -55,7 +49,7 @@ public class DeskProductEntity {
         return DeskProduct.builder()
                 .id(this.id)
                 .subCategoryId(this.productSubCategoryEntity.getId())
-                .aiImageId(this.aiImageEntity.getId())
+                .productCode(this.productCode)
                 .name(this.name)
                 .price(this.price)
                 .purchasePlace(this.purchasePlace)
@@ -63,8 +57,6 @@ public class DeskProductEntity {
                 .clickCount(this.clickCount)
                 .weight(this.weight)
                 .purchaseUrl(this.purchaseUrl)
-                .centerX(this.centerX)
-                .centerY(this.centerY)
                 .imagePath(this.imagePath)
                 .build();
 
@@ -74,7 +66,7 @@ public class DeskProductEntity {
 
         return DeskProductEntity.builder()
                 .productSubCategoryEntity(productSubCategoryEntity)
-                .aiImageEntity(aiImageEntity)
+                .productCode(deskProduct.getProductCode())
                 .name(deskProduct.getName())
                 .price(deskProduct.getPrice())
                 .purchasePlace(deskProduct.getPurchasePlace())
@@ -82,8 +74,6 @@ public class DeskProductEntity {
                 .clickCount(deskProduct.getClickCount())
                 .weight(deskProduct.getWeight())
                 .purchaseUrl(deskProduct.getPurchaseUrl())
-                .centerX(deskProduct.getCenterX())
-                .centerY(deskProduct.getCenterY())
                 .imagePath(deskProduct.getImagePath())
                 .build();
     }

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/infrastructure/repositoryImpl/AiImageRecommendedProductRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/infrastructure/repositoryImpl/AiImageRecommendedProductRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.kakaotech.ott.ott.recommendProduct.infrastructure.repositoryImpl;
+
+import com.kakaotech.ott.ott.aiImage.domain.repository.AiImageJpaRepository;
+import com.kakaotech.ott.ott.aiImage.infrastructure.entity.AiImageEntity;
+import com.kakaotech.ott.ott.global.exception.CustomException;
+import com.kakaotech.ott.ott.global.exception.ErrorCode;
+import com.kakaotech.ott.ott.recommendProduct.domain.model.AiImageRecommendedProduct;
+import com.kakaotech.ott.ott.recommendProduct.domain.repository.AiImageRecommendedProductJpaRepsitory;
+import com.kakaotech.ott.ott.recommendProduct.domain.repository.AiImageRecommendedProductRepository;
+import com.kakaotech.ott.ott.recommendProduct.domain.repository.DeskProductJpaRepository;
+import com.kakaotech.ott.ott.recommendProduct.infrastructure.entity.AiImageRecommendedProductEntity;
+import com.kakaotech.ott.ott.recommendProduct.infrastructure.entity.DeskProductEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class AiImageRecommendedProductRepositoryImpl implements AiImageRecommendedProductRepository {
+
+    private final AiImageRecommendedProductJpaRepsitory aiImageRecommendedProductJpaRepsitory;
+    private final AiImageJpaRepository aiImageJpaRepository;
+    private final DeskProductJpaRepository deskProductJpaRepository;
+
+    @Override
+    public AiImageRecommendedProduct save(AiImageRecommendedProduct aiImageRecommendedProduct) {
+
+        AiImageEntity aiImageEntity = aiImageJpaRepository.findById(aiImageRecommendedProduct.getAiImageId())
+                .orElseThrow(() -> new CustomException(ErrorCode.AIIMAGE_NOT_FOUND));
+
+        DeskProductEntity deskProductEntity = deskProductJpaRepository.findById(aiImageRecommendedProduct.getDeskProductId())
+                .orElseThrow(() -> new CustomException(ErrorCode.DESK_PRODUCT_NOT_FOUND));
+
+        AiImageRecommendedProductEntity aiImageRecommendedProductEntity = AiImageRecommendedProductEntity.from(aiImageRecommendedProduct, aiImageEntity, deskProductEntity);
+
+        return aiImageRecommendedProductJpaRepsitory.save(aiImageRecommendedProductEntity).toDomain();
+    }
+
+    @Override
+    public List<AiImageRecommendedProduct> findByAiImageIdAndDeskProductId(Long aiImageId, Long deskProductId) {
+
+        return aiImageRecommendedProductJpaRepsitory.findByAiImageEntity_IdAndDeskProductEntity_id(aiImageId, deskProductId)
+                .stream()
+                .map(AiImageRecommendedProductEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<AiImageRecommendedProduct> findByAiImageId(Long aiImageId) {
+
+        return aiImageRecommendedProductJpaRepsitory.findByAiImageEntity_Id(aiImageId)
+                .stream()
+                .map(AiImageRecommendedProductEntity::toDomain)
+                .toList();
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/infrastructure/repositoryImpl/DeskProductRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/infrastructure/repositoryImpl/DeskProductRepositoryImpl.java
@@ -31,14 +31,6 @@ public class DeskProductRepositoryImpl implements DeskProductRepository {
     }
 
     @Override
-    public List<DeskProduct> findByAiImageId(Long aiImageId) {
-        return deskProductJpaRepository.findByAiImageEntity_Id(aiImageId)
-                .stream()
-                .map(DeskProductEntity::toDomain)
-                .toList();
-    }
-
-    @Override
     public List<DeskProduct> findTop7ByWeight() {
         // DB에서 직접 weight 기준 상위 7개 조회
         List<DeskProductEntity> entities = deskProductJpaRepository.findByOrderByWeightDesc(PageRequest.of(0, 7));

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/presentation/controller/RecommendedProductController.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/presentation/controller/RecommendedProductController.java
@@ -1,0 +1,11 @@
+package com.kakaotech.ott.ott.recommendProduct.presentation.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/recommended-product")
+public class RecommendedProductController {
+
+
+}

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/presentation/dto/request/ProductDetailRequestDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/presentation/dto/request/ProductDetailRequestDto.java
@@ -23,15 +23,6 @@ public class ProductDetailRequestDto {
     @JsonProperty("purchase_url")
     private String purchaseUrl;
 
-    // 버전 업데이트 후 진행
-//    @NotNull(message = "center_x는 필수입니다.")
-//    @JsonProperty("center_x")
-//    private Integer centerX;
-//
-//    @NotNull(message = "center_y는 필수입니다.")
-//    @JsonProperty("center_y")
-//    private Integer centerY;
-
     @NotNull(message = "image_path는 필수입니다.")
     @JsonProperty("image_path")
     private String imagePath;
@@ -43,4 +34,15 @@ public class ProductDetailRequestDto {
     @NotNull(message = "sub_category는 필수입니다.")
     @JsonProperty("sub_category")
     private String subCategory;
+
+    // 버전 업데이트 후 진행
+    @JsonProperty("center_x")
+    private Integer centerX;
+
+    @JsonProperty("center_y")
+    private Integer centerY;
+
+    @NotNull(message = "product_code는 필수입니다.")
+    @JsonProperty("product_code")
+    private String productCode;
 }


### PR DESCRIPTION

### feat: DeskProduct와 AiImage 테이블 사이 관계 테이블 추가

### 설명
- DeskProduct와 AiImage 테이블의 N:M관계 수정
- DeskProduct와 AiImage 테이블의 관계 테이블인 AiImageRecommendProduct 테이블 생성
- 해당 테이블 추가됨으로 비즈니스 로직 및 repository, controller 변경
- DeskProduct 테이블 구조 변경