### PR TITLE
fix: 추천 제품 조회 시 해당 사용자 정보 조회 제거

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/application/serviceImpl/DeskProductServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/application/serviceImpl/DeskProductServiceImpl.java
@@ -23,7 +23,6 @@ import java.util.List;
 public class DeskProductServiceImpl implements DeskProductService {
 
     private final DeskProductRepository deskProductRepository;
-    private final UserAuthRepository userAuthRepository;
     private final ScrapRepository scrapRepository;
     private final ProductSubCategoryRepository productSubCategoryRepository;
 
@@ -35,7 +34,6 @@ public class DeskProductServiceImpl implements DeskProductService {
 
         List<DeskProductListResponseDto.DeskProducts> deskProductsList = deskProducts.stream()
                 .map(deskProduct -> {
-                    User user = userAuthRepository.findById(userId);
 
                     ProductSubCategory productSubCategory = productSubCategoryRepository.findById(deskProduct.getSubCategoryId());
 


### PR DESCRIPTION

### fix: 추천 제품 조회 시 해당 사용자 정보 조회 제거

### 설명
- 추천 제품 목록 및 상세 조회 시 해당 사용자의 정보 조회 로직 제거
- 정보 조회한다면 security에서 모든 사용자 허용하더라도 user_id가 null인 사용자를 조회하므로 예외 발생
