### PR TITLE
feat: 상품 주문 요청 시 카테부 인증 회원 확인

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/global/exception/ErrorCode.java
+++ b/src/main/java/com/kakaotech/ott/ott/global/exception/ErrorCode.java
@@ -20,7 +20,7 @@ public enum ErrorCode {
     USER_DELETED(HttpStatus.FORBIDDEN, "탈퇴한 사용자입니다."),
     LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "로그아웃 처리에 실패했습니다."),
     USER_ALREADY_AUTHENTICATED(HttpStatus.FORBIDDEN, "이미 추천인 코드를 등록하셨습니다."),
-    USER_NOT_VERIFIED(HttpStatus.FORBIDDEN, "추천인 코드를 등록해야 카카오 닉네임이 변경됩니다."),
+    USER_NOT_VERIFIED(HttpStatus.FORBIDDEN, "카테부 회원만 이용 가능합니다."),
     INVALID_INPUT_CODE(HttpStatus.BAD_REQUEST, "추천인 코드가 일치하지 않습니다."),
     DUPLICATE_NICKNAME_COMMUNITY(HttpStatus.CONFLICT, "이미 사용 중인 커뮤니티 닉네임입니다."),
     USER_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 사용자의 권한이 없습니다."),

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/application/serviceimpl/ProductOrderServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/application/serviceimpl/ProductOrderServiceImpl.java
@@ -1,5 +1,7 @@
 package com.kakaotech.ott.ott.productOrder.application.serviceimpl;
 
+import com.kakaotech.ott.ott.global.exception.CustomException;
+import com.kakaotech.ott.ott.global.exception.ErrorCode;
 import com.kakaotech.ott.ott.orderItem.domain.model.OrderItemStatus;
 import com.kakaotech.ott.ott.orderItem.domain.model.RefundReason;
 import com.kakaotech.ott.ott.product.domain.model.ProductImage;
@@ -47,6 +49,8 @@ public class ProductOrderServiceImpl implements ProductOrderService {
     public ProductOrderResponseDto create(ProductOrderRequestDto productOrderRequestDto, Long userId) {
 
         User user = userRepository.findById(userId);
+
+        user.checkVerifiedUser();
 
         List<OrderItem> orderItems = new ArrayList<>();
         int totalAmount = 0;
@@ -104,6 +108,11 @@ public class ProductOrderServiceImpl implements ProductOrderService {
     @Override
     @Transactional(readOnly = true)
     public MyProductOrderHistoryListResponseDto getProductOrderHistory(Long userId, Long lastId, int size) {
+
+        User user = userRepository.findById(userId);
+
+        user.checkVerifiedUser();
+
         Slice<ProductOrder> orders = productOrderRepository.findAllByUserId(userId, lastId, size);
 
         List<MyProductOrderHistoryResponseDto> dtoList = orders.stream().map(order -> {
@@ -148,6 +157,8 @@ public class ProductOrderServiceImpl implements ProductOrderService {
 
         User user = userRepository.findById(userId);
 
+        user.checkVerifiedUser();
+
         ProductOrder productOrder = productOrderRepository.findByIdAndUserId(orderId, userId);
         List<OrderItem> orderItems = orderItemRepository.findByProductOrderId(orderId);
 
@@ -191,6 +202,8 @@ public class ProductOrderServiceImpl implements ProductOrderService {
 
         User user = userRepository.findById(userId);
 
+        user.checkVerifiedUser();
+
         ProductOrder productOrder = productOrderRepository.findByIdAndUserId(orderId, userId);
 
         productOrder.deleteOrder();
@@ -203,6 +216,8 @@ public class ProductOrderServiceImpl implements ProductOrderService {
     public ProductOrderConfirmResponseDto confirmProductOrder(Long userId, Long orderId) {
 
         User user = userRepository.findById(userId);
+
+        user.checkVerifiedUser();
 
         ProductOrder productOrder = productOrderRepository.findByIdAndUserId(orderId, userId);
         productOrder.confirm();
@@ -225,6 +240,8 @@ public class ProductOrderServiceImpl implements ProductOrderService {
     public void partialCancelProductOrder(Long userId, Long orderId, ProductOrderPartialCancelRequestDto productOrderPartialCancelRequestDto) {
 
         User user = userRepository.findById(userId);
+
+        user.checkVerifiedUser();
 
         ProductOrder productOrder = productOrderRepository.findByIdAndUserId(orderId, userId);
         productOrder.partialCancel();
@@ -262,6 +279,8 @@ public class ProductOrderServiceImpl implements ProductOrderService {
     public void cancelProductOrder(Long userId, Long orderId) {
 
         User user = userRepository.findById(userId);
+
+        user.checkVerifiedUser();
 
         ProductOrder productOrder = productOrderRepository.findByIdAndUserId(orderId, userId);
         productOrder.cancel();

--- a/src/main/java/com/kakaotech/ott/ott/user/application/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/user/application/serviceImpl/UserServiceImpl.java
@@ -292,11 +292,10 @@ public class UserServiceImpl implements UserService {
         }
         // 카카오 닉네임 변경 (인증된 사용자만)
         if (userInfoUpdateRequestDto.getNicknameKakao() != null) {
-            if (user.isVerified()) {
-                user.updateNicknameKakao(userInfoUpdateRequestDto.getNicknameKakao());
-            } else {
-                throw new CustomException(ErrorCode.USER_NOT_VERIFIED);
-            }
+
+            user.checkVerifiedUser();
+
+            user.updateNicknameKakao(userInfoUpdateRequestDto.getNicknameKakao());
         }
 
         User savedUser = userRepository.update(user);

--- a/src/main/java/com/kakaotech/ott/ott/user/domain/model/User.java
+++ b/src/main/java/com/kakaotech/ott/ott/user/domain/model/User.java
@@ -1,5 +1,7 @@
 package com.kakaotech.ott.ott.user.domain.model;
 
+import com.kakaotech.ott.ott.global.exception.CustomException;
+import com.kakaotech.ott.ott.global.exception.ErrorCode;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -57,6 +59,12 @@ public class User {
     public void updateVerified(String nicknameKakao) {
         this.isVerified = true;
         this.nicknameKakao = nicknameKakao;
+    }
+
+    public void checkVerifiedUser() {
+
+        if (!this.isVerified())
+            throw new CustomException(ErrorCode.USER_NOT_VERIFIED);
     }
 
 }


### PR DESCRIPTION

### feat: 상품 주문 요청 시 카테부 인증 회원 확인

### 설명
- 서비스 상품 주문 요청 시 사용자의 is_verified 확인 후 응답
- 카테부 회원 인증 메서드 도메인 로직에 추가
- USER_NOT_VERIFIED 예외 문구 변경