### PR TITLE
fix: 판매가능 재고 dto 변경

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/product/application/serviceImpl/ProductServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/application/serviceImpl/ProductServiceImpl.java
@@ -247,6 +247,7 @@ public class ProductServiceImpl implements ProductService {
                 .originalPrice(variant.getPrice())
                 .discountPrice(null)
                 .discountRate(null)
+                .availableQuantity(variant.getAvailableQuantity())
                 .promotionEndAt(null)
                 .promotion(false)
                 .scraped(scraped)


### PR DESCRIPTION
## ✏️ PR 내용
### fix: 판매가능 재고 dto 변경

### 설명
> 설명: 변경 동기와 내용(무엇을, 어떻게)을 상세히 기술합니다.

일반 상품 조회 시 판매 가능 재고 필드가 null로 오는 문제 해결.