### PR TITLE
feat: 주문 중복 제거 체크 로직 변경

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/orderItem/domain/model/OrderItem.java
+++ b/src/main/java/com/kakaotech/ott/ott/orderItem/domain/model/OrderItem.java
@@ -62,6 +62,13 @@ public class OrderItem {
         this.pendingProductStatus = null;
     }
 
+    public void fail() {
+        if (this.status != OrderItemStatus.PENDING) throw new CustomException(ErrorCode.NOT_PENDING_STATE);
+
+        this.status = OrderItemStatus.FAILED;
+        this.pendingProductStatus = null;
+    }
+
     public void pay() {
         if (this.status != OrderItemStatus.PENDING) throw new CustomException(ErrorCode.NOT_PENDING_STATE);
 

--- a/src/main/java/com/kakaotech/ott/ott/orderItem/domain/model/OrderItemStatus.java
+++ b/src/main/java/com/kakaotech/ott/ott/orderItem/domain/model/OrderItemStatus.java
@@ -1,6 +1,7 @@
 package com.kakaotech.ott.ott.orderItem.domain.model;
 
 public enum OrderItemStatus {
+    FAILED,
     PENDING,
     PAID,
     DELIVERED,

--- a/src/main/java/com/kakaotech/ott/ott/orderItem/domain/repository/OrderItemRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/orderItem/domain/repository/OrderItemRepository.java
@@ -20,4 +20,6 @@ public interface OrderItemRepository {
     void refundOrderItem(List<OrderItem> orderItems);
 
     void confirmOrderItem(List<OrderItem> orderItems);
+
+    void deleteOrderItem(OrderItem orderItems);
 }

--- a/src/main/java/com/kakaotech/ott/ott/orderItem/infrastructure/entity/OrderItemEntity.java
+++ b/src/main/java/com/kakaotech/ott/ott/orderItem/infrastructure/entity/OrderItemEntity.java
@@ -105,6 +105,11 @@ public class OrderItemEntity {
                 .build();
     }
 
+    public void fail(OrderItem item) {
+        this.status = item.getStatus();
+        this.pendingProductStatus = item.getPendingProductStatus();
+    }
+
     public void pay(OrderItem item) {
         this.status = item.getStatus();
         this.pendingProductStatus = item.getPendingProductStatus();

--- a/src/main/java/com/kakaotech/ott/ott/orderItem/infrastructure/repositoryImpl/OrderItemRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/orderItem/infrastructure/repositoryImpl/OrderItemRepositoryImpl.java
@@ -145,4 +145,14 @@ public class OrderItemRepositoryImpl implements OrderItemRepository {
             entity.confirm(item);
         }
     }
+
+    @Override
+    public void deleteOrderItem(OrderItem orderItems) {
+
+        OrderItemEntity orderItemEntity = orderItemJpaRepository.findById(orderItems.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_ITEM_NOT_FOUND));
+
+        orderItemEntity.fail(orderItems);
+
+    }
 }

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/domain/model/ProductOrder.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/domain/model/ProductOrder.java
@@ -24,6 +24,8 @@ public class ProductOrder {
 
     private int discountAmount;
 
+    private String orderFingerprint;
+
     private LocalDateTime orderedAt;
 
     private LocalDateTime deliveredAt;
@@ -38,7 +40,7 @@ public class ProductOrder {
 
     private static final ULID ulid = new ULID();
 
-    public static ProductOrder createOrder(Long userId, int subtotalAmount, int discountAmount) {
+    public static ProductOrder createOrder(Long userId, int subtotalAmount, int discountAmount, String orderFingerprint) {
 
         return ProductOrder.builder()
                 .userId(userId)
@@ -46,7 +48,16 @@ public class ProductOrder {
                 .status(ProductOrderStatus.PENDING)
                 .subtotalAmount(subtotalAmount)
                 .discountAmount(discountAmount)
+                .orderFingerprint(orderFingerprint)
                 .build();
+    }
+
+    public void fail() {
+        if (this.status != ProductOrderStatus.PENDING)
+            throw new CustomException(ErrorCode.NOT_PENDING_STATE);
+
+        this.status = ProductOrderStatus.FAILED;
+        this.deletedAt = LocalDateTime.now();
     }
 
     public void pay() {
@@ -87,7 +98,7 @@ public class ProductOrder {
         this.status = ProductOrderStatus.PARTIALLY_CANCELED;
     }
 
-    public void cancelRefund() {
+    public void partialRefund() {
         if (!(this.status == ProductOrderStatus.DELIVERED || this.status == ProductOrderStatus.PARTIALLY_REFUNDED))
             throw new CustomException(ErrorCode.NOT_DELIVERED_STATE);
 

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/domain/model/ProductOrderStatus.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/domain/model/ProductOrderStatus.java
@@ -1,6 +1,7 @@
 package com.kakaotech.ott.ott.productOrder.domain.model;
 
 public enum ProductOrderStatus {
+    FAILED,
     PENDING,
     PAID,
     CONFIRMED,

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/domain/repository/ProductOrderJpaRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/domain/repository/ProductOrderJpaRepository.java
@@ -48,4 +48,14 @@ public interface ProductOrderJpaRepository extends JpaRepository<ProductOrderEnt
             "AND o.status = 'PENDING' " +
             "AND o.deletedAt IS NULL")
     List<ProductOrderEntity> findOrdersToAutoDelete(@Param("threshold") LocalDateTime threshold);
+
+    @Query("""
+        SELECT COUNT(p) > 0 FROM ProductOrderEntity p
+            WHERE p.userEntity.id = :userId
+                AND p.orderFingerprint = :fingerprint
+                AND p.status = 'PENDING'
+    """)
+    boolean existsByUserEntityIdAndFingerprint(
+            @Param("userId") Long userId,
+            @Param("fingerprint") String fingerprint);
 }

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/domain/repository/ProductOrderRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/domain/repository/ProductOrderRepository.java
@@ -1,6 +1,7 @@
 package com.kakaotech.ott.ott.productOrder.domain.repository;
 
 import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrder;
+import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrderStatus;
 import com.kakaotech.ott.ott.user.domain.model.User;
 import org.springframework.data.domain.Slice;
 
@@ -34,4 +35,6 @@ public interface ProductOrderRepository {
     List<ProductOrder> findOrdersToAutoDelete(LocalDateTime threshold);
 
     ProductOrder findByIdAndUserIdToPayment(Long orderId, Long userId);
+
+    boolean existsByUserIdAndFingerprint(Long userId, String fingerprint);
 }

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/infrastructure/entity/ProductOrderEntity.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/infrastructure/entity/ProductOrderEntity.java
@@ -40,6 +40,9 @@ public class ProductOrderEntity {
     @Column(name = "discount_amount", nullable = false)
     private int discountAmount;
 
+    @Column(name = "order_fingerprint", nullable = false, length = 64)
+    private String orderFingerprint;
+
     @CreatedDate
     @Column(name = "ordered_at", nullable = false, updatable = false)
     private LocalDateTime orderedAt;
@@ -68,6 +71,7 @@ public class ProductOrderEntity {
                 .status(this.status)
                 .subtotalAmount(this.subtotalAmount)
                 .discountAmount(this.discountAmount)
+                .orderFingerprint(this.orderFingerprint)
                 .orderedAt(this.orderedAt)
                 .deliveredAt(this.deliveredAt)
                 .confirmedAt(this.confirmedAt)
@@ -85,6 +89,7 @@ public class ProductOrderEntity {
                 .status(productOrder.getStatus())
                 .subtotalAmount(productOrder.getSubtotalAmount())
                 .discountAmount(productOrder.getDiscountAmount())
+                .orderFingerprint(productOrder.getOrderFingerprint())
                 .deliveredAt(productOrder.getDeliveredAt())
                 .confirmedAt(productOrder.getConfirmedAt())
                 .canceledAt(productOrder.getCanceledAt())

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/infrastructure/repositoryImpl/ProductOrderRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/infrastructure/repositoryImpl/ProductOrderRepositoryImpl.java
@@ -146,4 +146,10 @@ public class ProductOrderRepositoryImpl implements ProductOrderRepository {
                 .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND))
                 .toDomain();
     }
+
+    @Override
+    public boolean existsByUserIdAndFingerprint(Long userId, String fingerprint) {
+
+        return productOrderJpaRepository.existsByUserEntityIdAndFingerprint(userId, fingerprint);
+    }
 }

--- a/src/main/java/com/kakaotech/ott/ott/util/validator/OrderFingerprintUtil.java
+++ b/src/main/java/com/kakaotech/ott/ott/util/validator/OrderFingerprintUtil.java
@@ -1,0 +1,40 @@
+package com.kakaotech.ott.ott.util.validator;
+
+import com.kakaotech.ott.ott.productOrder.presentation.dto.request.ProductOrderRequestDto;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class OrderFingerprintUtil {
+    public static String generateFingerprint(List<ProductOrderRequestDto.ServiceProductDto> items) {
+        // 1. 정렬 (variantId 기준 정렬)
+        List<String> parts = items.stream()
+                .sorted(Comparator.comparingLong(ProductOrderRequestDto.ServiceProductDto::getVariantId))
+                .map(item -> item.getVariantId() + ":" + item.getQuantity())
+                .collect(Collectors.toList());
+
+        // 2. "1:2|2:1|5:3" 형식의 문자열 생성
+        String rawString = String.join("|", parts);
+
+        // 3. SHA-256 해싱
+        return sha256(rawString);
+    }
+
+    private static String sha256(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : hash) {
+                hexString.append(String.format("%02x", b));
+            }
+            return hexString.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 algorithm not available", e);
+        }
+    }
+}


### PR DESCRIPTION
### feat: 주문 중복 제거 체크 로직 변경

### 설명
- fingerprint 값을 통해 중복 주문 데이터 확인
- PENDING 상태의 데이터 존재하는지 확인
- 결제 실패 상태 변경
- 기존 방법 : variantsId를 통해 모든 데이터를 확인(2^n-1)
- 현재 방법 : fingerprint 값을 정렬해 해시 값으로 변경 (Nlog(n) + 1)