### PR TITLE
390 cancel payment

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/orderItem/domain/model/RefundReason.java
+++ b/src/main/java/com/kakaotech/ott/ott/orderItem/domain/model/RefundReason.java
@@ -1,7 +1,8 @@
 package com.kakaotech.ott.ott.orderItem.domain.model;
 
 public enum RefundReason {
-    CUSTOMER_REQUEST,   // 단순 변심
+    CUSTOMER_REQUEST,
+    CHANGE_MIND,   // 단순 변심
     OUT_OF_STOCK,       // 재고 부족
     DEFECTIVE_PRODUCT,  // 상품 불량
     WRONG_PRODUCT      // 오배송

--- a/src/main/java/com/kakaotech/ott/ott/orderItem/infrastructure/repositoryImpl/OrderItemRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/orderItem/infrastructure/repositoryImpl/OrderItemRepositoryImpl.java
@@ -116,7 +116,7 @@ public class OrderItemRepositoryImpl implements OrderItemRepository {
             if(entity == null)
                 throw new CustomException(ErrorCode.ORDER_ITEM_NOT_FOUND);
 
-            entity.refund(item);
+            entity.refundRequest(item);
         }
     }
 

--- a/src/main/java/com/kakaotech/ott/ott/payment/application/service/PaymentService.java
+++ b/src/main/java/com/kakaotech/ott/ott/payment/application/service/PaymentService.java
@@ -1,9 +1,13 @@
 package com.kakaotech.ott.ott.payment.application.service;
 
 import com.kakaotech.ott.ott.payment.presentation.dto.request.PaymentRequestDto;
+import com.kakaotech.ott.ott.payment.presentation.dto.request.RefundRequestDto;
 import com.kakaotech.ott.ott.payment.presentation.dto.response.PaymentResponseDto;
+import com.kakaotech.ott.ott.payment.presentation.dto.response.RefundResponseDto;
 
 public interface PaymentService {
 
     PaymentResponseDto createPayment(PaymentRequestDto paymentRequestDto, Long userId, Long orderId);
+
+    RefundResponseDto refundPayment(RefundRequestDto refundRequestDto, Long userId, Long orderId);
 }

--- a/src/main/java/com/kakaotech/ott/ott/payment/presentation/controller/PaymentController.java
+++ b/src/main/java/com/kakaotech/ott/ott/payment/presentation/controller/PaymentController.java
@@ -3,7 +3,9 @@ package com.kakaotech.ott.ott.payment.presentation.controller;
 import com.kakaotech.ott.ott.global.response.ApiResponse;
 import com.kakaotech.ott.ott.payment.application.service.PaymentService;
 import com.kakaotech.ott.ott.payment.presentation.dto.request.PaymentRequestDto;
+import com.kakaotech.ott.ott.payment.presentation.dto.request.RefundRequestDto;
 import com.kakaotech.ott.ott.payment.presentation.dto.response.PaymentResponseDto;
+import com.kakaotech.ott.ott.payment.presentation.dto.response.RefundResponseDto;
 import com.kakaotech.ott.ott.user.domain.model.UserPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -31,4 +33,18 @@ public class PaymentController {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("상품 결제 성공", paymentResponseDto));
     }
+
+    @PatchMapping
+    public ResponseEntity<ApiResponse<RefundResponseDto>> refundPayment(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long orderId,
+            @RequestBody @Valid RefundRequestDto refundRequestDto) {
+
+        Long userId = userPrincipal.getId();
+
+        RefundResponseDto refundResponseDto = paymentService.refundPayment(refundRequestDto, userId, orderId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("환불 요청 성공", refundResponseDto));
+    }
+
 }

--- a/src/main/java/com/kakaotech/ott/ott/payment/presentation/dto/request/RefundRequestDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/payment/presentation/dto/request/RefundRequestDto.java
@@ -1,0 +1,38 @@
+package com.kakaotech.ott.ott.payment.presentation.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kakaotech.ott.ott.orderItem.domain.model.RefundReason;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefundRequestDto {
+
+    @NotEmpty(message = "환불 요청 상품은 최소 1개 이상이어야 합니다")
+    @Valid
+    private List<RefundItemRequest> refundItems;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RefundItemRequest {
+        @NotNull(message = "품목 ID는 필수입니다")
+        @JsonProperty("orderItemId")
+        private Long orderItemId;
+
+        @NotNull(message = "환불 사유는 필수입니다")
+        @JsonProperty("reason")
+        private RefundReason reason;
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/payment/presentation/dto/response/RefundResponseDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/payment/presentation/dto/response/RefundResponseDto.java
@@ -1,0 +1,17 @@
+package com.kakaotech.ott.ott.payment.presentation.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefundResponseDto {
+    private Long orderId;
+}

--- a/src/main/java/com/kakaotech/ott/ott/product/application/serviceImpl/ProductServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/application/serviceImpl/ProductServiceImpl.java
@@ -54,11 +54,6 @@ public class ProductServiceImpl implements ProductService {
     @Override
     @Transactional
     public ProductCreateResponseDto createProduct(ProductCreateRequestDto requestDto, Long userId) throws IOException {
-        User user = userAuthRepository.findById(userId);
-        if (!user.getRole().equals(Role.ROLE_ADMIN)) {
-            throw new CustomException(ErrorCode.USER_FORBIDDEN);
-        }
-
         // 1. 상품 모델 생성
         Product product = Product.createProduct(
             requestDto.getProduct().getType(),

--- a/src/main/java/com/kakaotech/ott/ott/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/presentation/controller/ProductController.java
@@ -20,6 +20,7 @@ import jakarta.validation.constraints.Size;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -43,6 +44,7 @@ public class ProductController {
 
     private final ProductService productService;
 
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<ProductCreateResponseDto>> createProduct(
             @AuthenticationPrincipal UserPrincipal userPrincipal,

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/application/serviceimpl/ProductOrderServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/application/serviceimpl/ProductOrderServiceImpl.java
@@ -275,7 +275,7 @@ public class ProductOrderServiceImpl implements ProductOrderService {
             if (!item.getStatus().equals(OrderItemStatus.CONFIRMED) && !item.getStatus().equals(OrderItemStatus.CANCELED)) {
 
                 if (productOrderPartialCancelRequestDto.getOrderItemIds().contains(item.getId())) {
-                    item.cancel(RefundReason.CUSTOMER_REQUEST, LocalDateTime.now());
+                    item.cancel(RefundReason.CHANGE_MIND, LocalDateTime.now());
                     refundMoney += item.getRefundAmount();
 
                     cancelItems.add(item);
@@ -319,7 +319,7 @@ public class ProductOrderServiceImpl implements ProductOrderService {
 
         for(OrderItem item : orderItems)
             if(!item.getStatus().equals(OrderItemStatus.CANCELED) && !item.getStatus().equals(OrderItemStatus.CONFIRMED)) {
-                item.cancel(RefundReason.CUSTOMER_REQUEST, LocalDateTime.now());
+                item.cancel(RefundReason.CHANGE_MIND, LocalDateTime.now());
                 refundMoney += item.getRefundAmount();
 
                 if (item.getPromotionId() != null) {


### PR DESCRIPTION
## ✏️ PR 내용
### feat: 상품별 환불 요청 API 기능 추가

### 설명
> 설명: 변경 동기와 내용(무엇을, 어떻게)을 상세히 기술합니다.

이번 PR은 상품별 환불 요청 기능을 추가하기 위해
- PaymentController에 환불 요청 엔드포인트 추가
- refundPayment 비즈니스 로직 구현
  1. 인증된 사용자인지 확인
  2. 해당 주문을 생성한 사용자인지 확인
  3. 해당 주문의 환불 품목을 매칭하여 환불 요청(DELIVERED -> REFUND_REQUEST)