### PR TITLE
fix: 추천 상품 중복 저장 충돌 해결

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/repository/AiImageRecommendedProductJpaRepsitory.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/repository/AiImageRecommendedProductJpaRepsitory.java
@@ -1,13 +1,7 @@
 package com.kakaotech.ott.ott.recommendProduct.domain.repository;
 
-import com.kakaotech.ott.ott.post.infrastructure.entity.PostEntity;
 import com.kakaotech.ott.ott.recommendProduct.infrastructure.entity.AiImageRecommendedProductEntity;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
 import java.util.List;
 
 public interface AiImageRecommendedProductJpaRepsitory extends JpaRepository<AiImageRecommendedProductEntity, Long> {
@@ -15,5 +9,4 @@ public interface AiImageRecommendedProductJpaRepsitory extends JpaRepository<AiI
     List<AiImageRecommendedProductEntity> findByAiImageEntity_IdAndDeskProductEntity_id(Long aiImageId, Long deskProductId);
 
     List<AiImageRecommendedProductEntity> findByAiImageEntity_Id(Long aiImageId);
-
 }

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/repository/DeskProductJpaRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/repository/DeskProductJpaRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DeskProductJpaRepository extends JpaRepository<DeskProductEntity, Long> {
 
@@ -49,4 +50,7 @@ public interface DeskProductJpaRepository extends JpaRepository<DeskProductEntit
 """)
     void incrementClickCount(@Param("deskProductId") Long deskProductId, @Param("delta") Long delta);
 
+    boolean existsByProductCode(String productCode);
+
+    Optional<DeskProductEntity> findByProductCode(String productCode);
 }

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/repository/DeskProductRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/repository/DeskProductRepository.java
@@ -23,4 +23,8 @@ public interface DeskProductRepository {
     void batchUpdateWeights();
 
     void incrementClickCount(Long deskProductId, Long delta);
+
+    boolean existsByProductCode(String productCode);
+
+    DeskProduct findByProductCode(String productCode);
 }

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/infrastructure/repositoryImpl/AiImageRecommendedProductRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/infrastructure/repositoryImpl/AiImageRecommendedProductRepositoryImpl.java
@@ -58,4 +58,6 @@ public class AiImageRecommendedProductRepositoryImpl implements AiImageRecommend
                 .map(AiImageRecommendedProductEntity::toDomain)
                 .toList();
     }
+
+
 }

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/infrastructure/repositoryImpl/DeskProductRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/infrastructure/repositoryImpl/DeskProductRepositoryImpl.java
@@ -87,4 +87,18 @@ public class DeskProductRepositoryImpl implements DeskProductRepository {
 
         deskProductJpaRepository.incrementClickCount(deskProductId, delta);
     }
+
+    @Override
+    public boolean existsByProductCode(String productCode) {
+
+        return deskProductJpaRepository.existsByProductCode(productCode);
+    }
+
+    @Override
+    public DeskProduct findByProductCode(String productCode) {
+
+        return deskProductJpaRepository.findByProductCode(productCode)
+                .orElseThrow(() -> new CustomException(ErrorCode.DESK_PRODUCT_NOT_FOUND))
+                .toDomain();
+    }
 }


### PR DESCRIPTION

### fix: 추천 상품 중복 저장 충돌 해결

### 설명
- 추천 상품에 대해서 product_code가 UNIQUE 처리 되어 있어, 동일한 제품이 이미지 생성하며 들어올 경우 대비하지 않음
- 만약 해당 추천 상품이 이미 존재한다면 해당 상품 id값을 매핑
