### PR TITLE
feat: AiImage 조회 N+1 문제 해결

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/OttApplication.java
+++ b/src/main/java/com/kakaotech/ott/ott/OttApplication.java
@@ -2,7 +2,6 @@ package com.kakaotech.ott.ott;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.util.TimeZone;
@@ -12,8 +11,6 @@ import java.util.TimeZone;
 public class OttApplication {
 
 	public static void main(String[] args) {
-		TimeZone.setDefault(TimeZone.getTimeZone("UTC")); // ✅ UTC 기준
-
 		SpringApplication.run(OttApplication.class, args);
 	}
 

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/repository/AiImageRecommendedProductJpaRepsitory.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/repository/AiImageRecommendedProductJpaRepsitory.java
@@ -1,7 +1,11 @@
 package com.kakaotech.ott.ott.recommendProduct.domain.repository;
 
 import com.kakaotech.ott.ott.recommendProduct.infrastructure.entity.AiImageRecommendedProductEntity;
+import com.kakaotech.ott.ott.recommendProduct.presentation.dto.response.RecommendedProductProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.List;
 
 public interface AiImageRecommendedProductJpaRepsitory extends JpaRepository<AiImageRecommendedProductEntity, Long> {
@@ -9,4 +13,24 @@ public interface AiImageRecommendedProductJpaRepsitory extends JpaRepository<AiI
     List<AiImageRecommendedProductEntity> findByAiImageEntity_IdAndDeskProductEntity_id(Long aiImageId, Long deskProductId);
 
     List<AiImageRecommendedProductEntity> findByAiImageEntity_Id(Long aiImageId);
+
+    @Query("""
+    SELECT 
+        dp.id AS productId,
+        dp.name AS productName,
+        dp.imagePath AS imagePath,
+        dp.price AS price,
+        dp.purchaseUrl AS purchaseUrl,
+        CASE WHEN s.id IS NOT NULL THEN true ELSE false END AS isScrapped,
+        arp.centerX AS centerX,
+        arp.centerY AS centerY,
+        dp.weight AS weight
+    FROM AiImageRecommendedProductEntity arp
+    JOIN arp.deskProductEntity dp
+    LEFT JOIN ScrapEntity s ON s.userEntity.id = :userId AND s.type = 'PRODUCT' AND s.targetId = dp.id
+    WHERE arp.aiImageEntity.id = :aiImageId
+""")
+    List<RecommendedProductProjection> findWithProductAndScrap(@Param("aiImageId") Long aiImageId,
+                                                               @Param("userId") Long userId);
+
 }

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/repository/AiImageRecommendedProductRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/domain/repository/AiImageRecommendedProductRepository.java
@@ -1,6 +1,7 @@
 package com.kakaotech.ott.ott.recommendProduct.domain.repository;
 
 import com.kakaotech.ott.ott.recommendProduct.domain.model.AiImageRecommendedProduct;
+import com.kakaotech.ott.ott.recommendProduct.presentation.dto.response.RecommendedProductProjection;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
@@ -12,4 +13,6 @@ public interface AiImageRecommendedProductRepository {
     List<AiImageRecommendedProduct> findByAiImageIdAndDeskProductId(Long aiImageId, Long deskProductId);
 
     List<AiImageRecommendedProduct> findByAiImageId(Long aiImageId);
+
+    List<RecommendedProductProjection> findWithProductAndScrap(Long aiImageId, Long userId);
 }

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/infrastructure/repositoryImpl/AiImageRecommendedProductRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/infrastructure/repositoryImpl/AiImageRecommendedProductRepositoryImpl.java
@@ -12,6 +12,7 @@ import com.kakaotech.ott.ott.recommendProduct.domain.repository.AiImageRecommend
 import com.kakaotech.ott.ott.recommendProduct.domain.repository.DeskProductJpaRepository;
 import com.kakaotech.ott.ott.recommendProduct.infrastructure.entity.AiImageRecommendedProductEntity;
 import com.kakaotech.ott.ott.recommendProduct.infrastructure.entity.DeskProductEntity;
+import com.kakaotech.ott.ott.recommendProduct.presentation.dto.response.RecommendedProductProjection;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -57,6 +58,12 @@ public class AiImageRecommendedProductRepositoryImpl implements AiImageRecommend
                 .stream()
                 .map(AiImageRecommendedProductEntity::toDomain)
                 .toList();
+    }
+
+    @Override
+    public List<RecommendedProductProjection> findWithProductAndScrap(Long aiImageId, Long userId) {
+
+        return aiImageRecommendedProductJpaRepsitory.findWithProductAndScrap(aiImageId, userId);
     }
 
 

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/presentation/dto/response/RecommendedProductProjection.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/presentation/dto/response/RecommendedProductProjection.java
@@ -1,0 +1,14 @@
+package com.kakaotech.ott.ott.recommendProduct.presentation.dto.response;
+
+public interface RecommendedProductProjection {
+    Long getProductId();
+    String getProductName();
+    String getImagePath();
+    int getPrice();
+    String getPurchaseUrl();
+    boolean getIsScrapped();
+    Integer getCenterX();
+    Integer getCenterY();
+    Integer getWeight();
+}
+


### PR DESCRIPTION
## ✅ 체크 리스트 (PR 올리기 전 아래 내용을 확인해 주세요)

## ✏️ PR 내용
### feat: AiImage 조회 N+1 문제 해결

### 설명
- 생성된 AI 이미지 조회 시 이미지 기반으로 생성된 제품 당 스크랩 여부를 각각 조회
- 즉 추천 상품이 N개일 때, 스크랩 여부 N번 조회
- 기존 쿼리 사용자 조회(1회) + 이미지 조회(1회) + 추천 목록 조회(1회) + 상품에 대한 스크랩 여부 조회(N번) = 18회 이상 조회
- DTO Projection으로 필요한 컬럼 한 번에 조회
- 수정 후 사용자 조회(1회) + 이미지 조회(1회) + 상품과 스크랩 여부 조회(1회) = 3회
