### PR TITLE
feat: 서비스 상품 목록 페이지 queryDSL 적용

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/product/application/serviceImpl/ProductServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/application/serviceImpl/ProductServiceImpl.java
@@ -10,10 +10,12 @@ import com.kakaotech.ott.ott.post.domain.model.Post;
 import com.kakaotech.ott.ott.post.presentation.dto.response.PopularSetupDto;
 import com.kakaotech.ott.ott.postImage.domain.PostImage;
 import com.kakaotech.ott.ott.product.domain.model.*;
+import com.kakaotech.ott.ott.product.domain.repository.*;
 import com.kakaotech.ott.ott.product.presentation.dto.response.ProductGetResponseDto;
 import com.kakaotech.ott.ott.product.presentation.dto.response.ProductListResponseDto;
 import com.kakaotech.ott.ott.product.presentation.dto.response.PromotionProductsDto;
 import com.kakaotech.ott.ott.scrap.domain.model.ScrapType;
+import com.kakaotech.ott.ott.scrap.domain.repository.ScrapQueryRepository;
 import com.kakaotech.ott.ott.scrap.domain.repository.ScrapRepository;
 import com.kakaotech.ott.ott.util.KstDateTime;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,10 +27,6 @@ import com.kakaotech.ott.ott.aiImage.application.serviceImpl.S3Uploader;
 import com.kakaotech.ott.ott.global.exception.CustomException;
 import com.kakaotech.ott.ott.global.exception.ErrorCode;
 import com.kakaotech.ott.ott.product.application.service.ProductService;
-import com.kakaotech.ott.ott.product.domain.repository.ProductImageRepository;
-import com.kakaotech.ott.ott.product.domain.repository.ProductPromotionRepository;
-import com.kakaotech.ott.ott.product.domain.repository.ProductRepository;
-import com.kakaotech.ott.ott.product.domain.repository.ProductVariantRepository;
 import com.kakaotech.ott.ott.product.presentation.dto.request.ProductCreateRequestDto;
 import com.kakaotech.ott.ott.product.presentation.dto.request.PromotionDto;
 import com.kakaotech.ott.ott.product.presentation.dto.request.VariantDto;
@@ -45,13 +43,14 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ProductServiceImpl implements ProductService {
 
-    private final UserAuthRepository userAuthRepository;
     private final ProductRepository productRepository;
     private final ProductVariantRepository variantRepository;
     private final ProductImageRepository imageRepository;
     private final ProductPromotionRepository promotionRepository;
     private final ScrapRepository scrapRepository;
     private final S3Uploader s3Uploader;
+    private final ProductVariantQueryRepository productVariantQueryRepository;
+    private final ScrapQueryRepository scrapQueryRepository;
 
     @Value("${cloud.aws.s3.base-url}")
     private String baseUrl;
@@ -118,39 +117,60 @@ public class ProductServiceImpl implements ProductService {
         return productGetResponseDto;
     }
 
+//    @Override
+//    @Transactional(readOnly = true)
+//    public ProductListResponseDto getProductList(Long userId, ProductType productType, PromotionType promotionType,
+//                                                 Long lastVariantId, int size) {
+//        // 상품 목록 조회
+//        List<ProductListResponseDto.Products> productDtos;
+//        List<ProductVariant> variants;
+//        if (promotionType != null) {
+//            // 특가 상품 조회
+//            variants = variantRepository.findPromotionVariantsByCursor(promotionType, lastVariantId, size);
+//        } else {
+//            // 일반 상품 조회
+//            variants = variantRepository.findNormalVariantsByCursor(productType, lastVariantId, size);
+//        }
+//
+//        // Variant를 DTO로 변환
+//        productDtos = variants.stream()
+//                .map(variant -> convertVariantToProductListDto(variant, userId, promotionType != null))
+//                .collect(Collectors.toList());
+//
+//        // 페이지네이션 정보
+//        boolean hasNext = productDtos.size() == size;
+//        Long nextLastVariantId = hasNext && !productDtos.isEmpty()
+//                ? variants.get(variants.size() - 1).getId()
+//                : null;
+//
+//        ProductListResponseDto.Pagination pagination = new ProductListResponseDto.Pagination(
+//                size, nextLastVariantId, hasNext);
+//
+//        return ProductListResponseDto.builder()
+//                .products(productDtos)
+//                .pagination(pagination)
+//                .build();
+//    }
+
     @Override
     @Transactional(readOnly = true)
     public ProductListResponseDto getProductList(Long userId, ProductType productType, PromotionType promotionType,
                                                  Long lastVariantId, int size) {
-        // 상품 목록 조회
-        List<ProductListResponseDto.Products> productDtos;
-        List<ProductVariant> variants;
-        if (promotionType != null) {
-            // 특가 상품 조회
-            variants = variantRepository.findPromotionVariantsByCursor(promotionType, lastVariantId, size);
-        } else {
-            // 일반 상품 조회
-            variants = variantRepository.findNormalVariantsByCursor(productType, lastVariantId, size);
-        }
 
-        // Variant를 DTO로 변환
-        productDtos = variants.stream()
-                .map(variant -> convertVariantToProductListDto(variant, userId, promotionType != null))
-                .collect(Collectors.toList());
+        ProductListResponseDto dto = productVariantQueryRepository
+                .findProductListByCursor(userId, productType, promotionType, lastVariantId, size);
 
-        // 페이지네이션 정보
-        boolean hasNext = productDtos.size() == size;
-        Long nextLastVariantId = hasNext && !productDtos.isEmpty()
-                ? variants.get(variants.size() - 1).getId()
-                : null;
+        List<Long> variantIds = dto.getProducts().stream()
+                .map(ProductListResponseDto.Products::getVariantId)
+                .toList();
 
-        ProductListResponseDto.Pagination pagination = new ProductListResponseDto.Pagination(
-                size, nextLastVariantId, hasNext);
+        Map<Long, Boolean> scrapMap = scrapQueryRepository.findScrapMapByUserIdAndVariantIds(userId, variantIds);
 
-        return ProductListResponseDto.builder()
-                .products(productDtos)
-                .pagination(pagination)
-                .build();
+        dto.getProducts().forEach(p ->
+                p.setScraped(scrapMap.getOrDefault(p.getVariantId(), false))
+        );
+
+        return dto;
     }
 
     @Override

--- a/src/main/java/com/kakaotech/ott/ott/product/domain/repository/ProductVariantQueryRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/domain/repository/ProductVariantQueryRepository.java
@@ -1,0 +1,11 @@
+package com.kakaotech.ott.ott.product.domain.repository;
+
+import com.kakaotech.ott.ott.product.domain.model.ProductType;
+import com.kakaotech.ott.ott.product.domain.model.PromotionType;
+import com.kakaotech.ott.ott.product.presentation.dto.response.ProductListResponseDto;
+
+public interface ProductVariantQueryRepository {
+
+    ProductListResponseDto findProductListByCursor(Long userId, ProductType productType, PromotionType promotionType,
+            Long lastVariantId, int size);
+}

--- a/src/main/java/com/kakaotech/ott/ott/product/infrastructure/repositoryImpl/ProductVariantQueryRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/infrastructure/repositoryImpl/ProductVariantQueryRepositoryImpl.java
@@ -1,0 +1,111 @@
+package com.kakaotech.ott.ott.product.infrastructure.repositoryImpl;
+
+import com.kakaotech.ott.ott.product.domain.model.ProductType;
+import com.kakaotech.ott.ott.product.domain.model.PromotionType;
+import com.kakaotech.ott.ott.product.domain.repository.ProductVariantQueryRepository;
+import com.kakaotech.ott.ott.product.infrastructure.entity.QProductEntity;
+import com.kakaotech.ott.ott.product.infrastructure.entity.QProductImageEntity;
+import com.kakaotech.ott.ott.product.infrastructure.entity.QProductPromotionEntity;
+import com.kakaotech.ott.ott.product.infrastructure.entity.QProductVariantEntity;
+import com.kakaotech.ott.ott.product.presentation.dto.response.ProductListResponseDto;
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductVariantQueryRepositoryImpl implements ProductVariantQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private final QProductVariantEntity variant = QProductVariantEntity.productVariantEntity;
+    private final QProductEntity product = QProductEntity.productEntity;
+    private final QProductImageEntity image = QProductImageEntity.productImageEntity;
+    private final QProductPromotionEntity promotion = QProductPromotionEntity.productPromotionEntity;
+
+
+    @Override
+    public ProductListResponseDto findProductListByCursor(Long userId, ProductType productType, PromotionType promotionType, Long lastVariantId, int size) {
+
+        List<ProductListResponseDto.Products> result = queryFactory
+                .select(productListProjection())
+                .distinct()
+                .from(variant)
+                .join(variant.productEntity, product)
+                .leftJoin(variant.images, image).on(image.sequence.eq(1))
+                .leftJoin(variant.promotions, promotion)
+                .where(buildWhereConditions(productType, promotionType, lastVariantId))
+                .groupBy(variant.id, product.id, promotion.id)
+                .orderBy(variant.id.desc())
+                .limit(size)
+                .fetch();
+
+        boolean hasNext = result.size() == size;
+        Long nextLastVariantId = hasNext ? result.get(result.size() - 1).getVariantId() : null;
+
+        ProductListResponseDto.Pagination pagination = ProductListResponseDto.Pagination.builder()
+                .size(size)
+                .lastVariantId(nextLastVariantId)
+                .hasNext(hasNext)
+                .build();
+
+        return ProductListResponseDto.builder()
+                .products(result)
+                .pagination(pagination)
+                .build();
+    }
+
+    private ConstructorExpression<ProductListResponseDto.Products> productListProjection() {
+        return Projections.constructor(ProductListResponseDto.Products.class,
+                product.id,
+                product.name,
+                product.type.stringValue(),
+                variant.id,
+                variant.name,
+                image.imageUuid.max(),
+                variant.price,
+                promotion.discountPrice,
+                promotion.rate,
+                promotion.startAt,
+                promotion.endAt,
+                variant.totalQuantity.subtract(variant.reservedQuantity).subtract(variant.soldQuantity),
+                promotion.id.isNotNull(),
+                Expressions.constant(false),
+                product.createdAt
+        );
+    }
+
+    private BooleanExpression[] buildWhereConditions(ProductType productType,
+                                                     PromotionType promotionType,
+                                                     Long lastVariantId) {
+
+        return new BooleanExpression[] {
+                productTypeEq(productType),
+                promotionTypeEq(promotionType),
+                lastVariantIdLt(lastVariantId)
+        };
+    }
+    private BooleanExpression productTypeEq(ProductType productType) {
+        return productType != null ? product.type.eq(productType) : null;
+    }
+
+    private BooleanExpression promotionTypeEq(PromotionType promotionType) {
+        if (promotionType != null) {
+            return promotion.type.eq(promotionType);
+        } else {
+            // promotionType이 null일 때는 promotion이 없는 상품만 조회
+            return promotion.id.isNull();
+        }
+    }
+
+    private BooleanExpression lastVariantIdLt(Long lastVariantId) {
+        return lastVariantId != null ? variant.id.lt(lastVariantId) : null;
+    }
+
+}

--- a/src/main/java/com/kakaotech/ott/ott/product/infrastructure/repositoryImpl/ProductVariantRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/infrastructure/repositoryImpl/ProductVariantRepositoryImpl.java
@@ -9,14 +9,11 @@ import com.kakaotech.ott.ott.product.domain.model.VariantStatus;
 import com.kakaotech.ott.ott.product.domain.repository.ProductVariantJpaRepository;
 import com.kakaotech.ott.ott.product.domain.repository.ProductVariantRepository;
 import com.kakaotech.ott.ott.product.infrastructure.entity.ProductEntity;
-import com.kakaotech.ott.ott.product.infrastructure.entity.ProductImageEntity;
-import com.kakaotech.ott.ott.product.infrastructure.entity.ProductPromotionEntity;
 import com.kakaotech.ott.ott.product.infrastructure.entity.ProductVariantEntity;
 import com.kakaotech.ott.ott.product.domain.repository.ProductJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.List;
@@ -33,7 +30,6 @@ public class ProductVariantRepositoryImpl implements ProductVariantRepository {
     private final ProductJpaRepository productJpaRepository;
 
     @Override
-    @Transactional
     public ProductVariant save(ProductVariant variant) {
         // 상품 존재 여부 확인
         ProductEntity productEntity = productJpaRepository.findById(variant.getProductId())
@@ -50,7 +46,6 @@ public class ProductVariantRepositoryImpl implements ProductVariantRepository {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public ProductVariant findById(Long variantId) {
         return productVariantJpaRepository.findByIdWithProduct(variantId)
                 .map(entity -> {
@@ -63,7 +58,6 @@ public class ProductVariantRepositoryImpl implements ProductVariantRepository {
     }
 
     @Override
-    @Transactional
     public ProductVariant update(ProductVariant variant) {
         ProductVariantEntity entity = productVariantJpaRepository.findById(variant.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND)); // 적절한 에러코드로 변경 필요
@@ -82,7 +76,6 @@ public class ProductVariantRepositoryImpl implements ProductVariantRepository {
     }
 
     @Override
-    @Transactional
     public void delete(Long variantId) {
         ProductVariantEntity entity = productVariantJpaRepository.findById(variantId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND)); // 적절한 에러코드로 변경 필요
@@ -91,7 +84,6 @@ public class ProductVariantRepositoryImpl implements ProductVariantRepository {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<ProductVariant> findByProductId(Long productId) {
         return productVariantJpaRepository.findByProductEntityId(productId)
                 .stream()
@@ -100,7 +92,6 @@ public class ProductVariantRepositoryImpl implements ProductVariantRepository {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<ProductVariant> findByProductIdAndStatus(Long productId, VariantStatus status) {
         return productVariantJpaRepository.findByProductIdAndStatus(productId, status.name())
                 .stream()
@@ -109,13 +100,11 @@ public class ProductVariantRepositoryImpl implements ProductVariantRepository {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public boolean existsByProductEntityIdAndName(Long productId, String name) {
         return productVariantJpaRepository.existsByProductEntityIdAndName(productId, name);
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<ProductVariant> findAvailableVariants(Long productId) {
         return productVariantJpaRepository.findAvailableVariants(productId)
                 .stream()
@@ -124,7 +113,6 @@ public class ProductVariantRepositoryImpl implements ProductVariantRepository {
     }
 
     @Override
-    @Transactional
     public void updateTotalQuantity(Long variantId, int totalQuantity) {
         // 1. 입력 검증
         if (totalQuantity < 0) {
@@ -137,7 +125,6 @@ public class ProductVariantRepositoryImpl implements ProductVariantRepository {
     }
 
     @Override
-    @Transactional
     public void reserveStock(Long variantId, int quantity) {
         // 1. 입력 검증
         validateQuantity(quantity);
@@ -162,7 +149,6 @@ public class ProductVariantRepositoryImpl implements ProductVariantRepository {
     }
 
     @Override
-    @Transactional
     public void cancelReservation(Long variantId, int quantity) {
         // 1. 입력 검증
         validateQuantity(quantity);
@@ -227,7 +213,6 @@ public class ProductVariantRepositoryImpl implements ProductVariantRepository {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<ProductVariant> findNormalVariantsByCursor(ProductType productType, Long lastVariantId, int size) {
         List<ProductVariantEntity> entities = productVariantJpaRepository.findNormalVariantsByCursor(
                 productType, lastVariantId, PageRequest.of(0, size));
@@ -242,7 +227,6 @@ public class ProductVariantRepositoryImpl implements ProductVariantRepository {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<ProductVariant> findPromotionVariantsByCursor(PromotionType promotionType, Long lastVariantId, int size) {
         // 1단계: Variant와 Product만 조회
         List<ProductVariantEntity> entities = productVariantJpaRepository.findPromotionVariantsByCursor(
@@ -298,7 +282,6 @@ public class ProductVariantRepositoryImpl implements ProductVariantRepository {
     }
 
     @Override
-    @Transactional
     public void incrementScrapCount(Long variantId, Long delta) {
         ProductVariantEntity productVariantEntity = productVariantJpaRepository.findById(variantId)
                 .orElseThrow(() -> new CustomException(ErrorCode.VARIANT_NOT_FOUND));

--- a/src/main/java/com/kakaotech/ott/ott/product/presentation/dto/response/ProductListResponseDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/presentation/dto/response/ProductListResponseDto.java
@@ -6,6 +6,7 @@ import com.kakaotech.ott.ott.util.KstDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -19,6 +20,7 @@ public class ProductListResponseDto {
     private final Pagination pagination;
 
     @Getter
+    @Setter
     @Builder
     @AllArgsConstructor
     public static class Products {
@@ -53,6 +55,10 @@ public class ProductListResponseDto {
         private final Integer availableQuantity;
 
         @JsonFormat(timezone = "Asia/Seoul")
+        @JsonProperty("promotion_start_at")
+        private final LocalDateTime promotionStartAt;
+
+        @JsonFormat(timezone = "Asia/Seoul")
         @JsonProperty("promotion_end_at")
         private final LocalDateTime promotionEndAt;
 
@@ -60,10 +66,32 @@ public class ProductListResponseDto {
         private final boolean promotion;
 
         @JsonProperty("scraped")
-        private final boolean scraped;
+        private boolean scraped;
 
         @JsonProperty("created_at")
         private KstDateTime createdAt;
+
+        public Products(Long productId, String productName, String productType,
+                        Long variantId, String variantName, String imageUrl,
+                        Integer originalPrice, Integer discountPrice, BigDecimal discountRate,
+                        LocalDateTime promotionStartAt, LocalDateTime promotionEndAt, Integer availableQuantity,
+                        boolean promotion, boolean scraped, LocalDateTime createdAt) {
+            this.productId = productId;
+            this.productName = productName;
+            this.productType = productType;
+            this.variantId = variantId;
+            this.variantName = variantName;
+            this.imageUrl = imageUrl;
+            this.originalPrice = originalPrice;
+            this.discountPrice = discountPrice;
+            this.discountRate = discountRate;
+            this.promotionStartAt =
+            this.promotionEndAt = promotionEndAt;
+            this.availableQuantity = availableQuantity;
+            this.promotion = promotion;
+            this.scraped = scraped;
+            this.createdAt = new KstDateTime(createdAt);
+        }
     }
 
     @Getter
@@ -72,7 +100,7 @@ public class ProductListResponseDto {
     public static class Pagination {
         private final int size;
 
-        @JsonProperty("last_variant_id")
+        @JsonProperty("last_product_id")
         private final Long lastVariantId;
         @JsonProperty("has_next")
         private final boolean hasNext;

--- a/src/main/java/com/kakaotech/ott/ott/scrap/domain/repository/ScrapQueryRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/scrap/domain/repository/ScrapQueryRepository.java
@@ -1,0 +1,10 @@
+package com.kakaotech.ott.ott.scrap.domain.repository;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ScrapQueryRepository {
+
+    Map<Long, Boolean> findScrapMapByUserIdAndVariantIds(Long userId, List<Long> variantIds);
+
+}

--- a/src/main/java/com/kakaotech/ott/ott/scrap/infrastructure/repositoryImpl/ScrapQueryRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/scrap/infrastructure/repositoryImpl/ScrapQueryRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.kakaotech.ott.ott.scrap.infrastructure.repositoryImpl;
+
+import com.kakaotech.ott.ott.scrap.domain.repository.ScrapQueryRepository;
+import com.kakaotech.ott.ott.scrap.infrastructure.entity.QScrapEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class ScrapQueryRepositoryImpl implements ScrapQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    QScrapEntity scrap = QScrapEntity.scrapEntity;
+
+    @Override
+    public Map<Long, Boolean> findScrapMapByUserIdAndVariantIds(Long userId, List<Long> variantIds) {
+        if (userId == null || variantIds == null || variantIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return queryFactory
+                .select(scrap.targetId, scrap.id.count().gt(0))
+                .from(scrap)
+                .where(scrap.userEntity.id.eq(userId), scrap.targetId.in(variantIds))
+                .groupBy(scrap.targetId)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(scrap.targetId),
+                        tuple -> tuple.get(scrap.id.count().gt(0))
+                ));
+    }
+
+}


### PR DESCRIPTION
## ✏️ PR 내용
### feat: 서비스 상품 목록 페이지 queryDSL 적용

### 설명
- 서비스 상품 목록 페이지 queryDSL 적용
- 총 3단계 과정
- 첫번째 단계 : queryDSL 미적용
- 두번째 단계 : queryDSL 적용
- 세번째 단계 : queryDSL 적용 + 이미지 가져오기 최적화 + distinct 적용
- 평균 응답 시간 2.4초 -> 1.3초 -> 0.8초
- 최대 응답 시간 9.5초 -> 5.3초 -> 4.5초
- 처리량 30.9 req/sec -> 54.8 req/sec -> 88 req/sec