### PR TITLE
feat: 주문 내역 조회 N+1 문제 해결

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/orderItem/domain/repository/OrderItemQueryRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/orderItem/domain/repository/OrderItemQueryRepository.java
@@ -1,0 +1,10 @@
+package com.kakaotech.ott.ott.orderItem.domain.repository;
+
+import com.kakaotech.ott.ott.productOrder.presentation.dto.response.ProductInfoDto;
+
+import java.util.List;
+
+public interface OrderItemQueryRepository {
+
+    List<ProductInfoDto> findAllByOrderIds(List<Long> orderIds);
+}

--- a/src/main/java/com/kakaotech/ott/ott/orderItem/infrastructure/repositoryImpl/OrderItemQueryRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/orderItem/infrastructure/repositoryImpl/OrderItemQueryRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.kakaotech.ott.ott.orderItem.infrastructure.repositoryImpl;
+
+import com.kakaotech.ott.ott.orderItem.domain.repository.OrderItemQueryRepository;
+import com.kakaotech.ott.ott.orderItem.infrastructure.entity.QOrderItemEntity;
+import com.kakaotech.ott.ott.product.infrastructure.entity.QProductImageEntity;
+import com.kakaotech.ott.ott.product.infrastructure.entity.QProductVariantEntity;
+import com.kakaotech.ott.ott.productOrder.presentation.dto.response.ProductInfoDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderItemQueryRepositoryImpl implements OrderItemQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    QOrderItemEntity orderItem = QOrderItemEntity.orderItemEntity;
+    QProductVariantEntity productVariant = QProductVariantEntity.productVariantEntity;
+    QProductImageEntity productImage = QProductImageEntity.productImageEntity;
+
+    @Override
+    public List<ProductInfoDto> findAllByOrderIds(List<Long> orderIds) {
+        return queryFactory
+                .select(Projections.constructor(ProductInfoDto.class,
+                        orderItem.productOrderEntity.id,
+                        productVariant.id,
+                        productVariant.name,
+                        productImage.imageUuid,
+                        orderItem.quantity,
+                        orderItem.finalPrice.divide(orderItem.quantity),
+                        orderItem.status.stringValue()
+                ))
+                .from(orderItem)
+                .join(productVariant).on(orderItem.productVariantEntity.id.eq(productVariant.id))
+                .leftJoin(productImage).on(
+                        productImage.variantEntity.id.eq(productVariant.productEntity.id)
+                                .and(productImage.sequence.eq(1))
+                )
+                .where(orderItem.productOrderEntity.id.in(orderIds))
+                .fetch();
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/productOrder/presentation/dto/response/ProductInfoDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/presentation/dto/response/ProductInfoDto.java
@@ -1,0 +1,17 @@
+package com.kakaotech.ott.ott.productOrder.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProductInfoDto {
+
+    private Long orderId;
+    private Long productId;
+    private String productName;
+    private String imagePath;
+    private int quantity;
+    private int unitPrice;
+    private String itemStatus;
+}


### PR DESCRIPTION


## ✏️ PR 내용
### feat: 주문 내역 조회 N+1 문제 해결

### 설명
- 주문 내역 조회 N+1 문제 해결
- 기존 수십건 ~ 조회되던 쿼리를 6회로 감소
- QueryDSL을 적용하여 필요 데이터 한번에 조회
- DTO Projection으로 불필요한 데이터 제외