### PR TITLE
fix: 상품 목록 보이지 않는 것 해결

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/product/infrastructure/repositoryImpl/ProductVariantQueryRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/infrastructure/repositoryImpl/ProductVariantQueryRepositoryImpl.java
@@ -78,7 +78,7 @@ public class ProductVariantQueryRepositoryImpl implements ProductVariantQueryRep
                 promotion.startAt,
                 promotion.endAt,
                 variant.totalQuantity.subtract(variant.reservedQuantity).subtract(variant.soldQuantity),
-                promotion.id.isNotNull(),
+                variant.isOnPromotion,
                 Expressions.constant(false),
                 product.createdAt
         );
@@ -100,11 +100,11 @@ public class ProductVariantQueryRepositoryImpl implements ProductVariantQueryRep
 
     private BooleanExpression promotionTypeConditional(PromotionType promotionType) {
         if (promotionType != null) {
-            return promotion.type.eq(promotionType)
+            return variant.isOnPromotion.eq(true)
                     .and(promotion.status.in(PromotionStatus.ACTIVE, PromotionStatus.SOLD_OUT))
                     .and(promotion.endAt.after(LocalDateTime.now()));
         } else {
-            return promotion.id.isNull(); // 일반 상품만 조회
+            return variant.isOnPromotion.eq(false); // 일반 상품만 조회
         }
     }
 

--- a/src/main/java/com/kakaotech/ott/ott/product/presentation/dto/response/ProductListResponseDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/presentation/dto/response/ProductListResponseDto.java
@@ -1,6 +1,5 @@
 package com.kakaotech.ott.ott.product.presentation.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.kakaotech.ott.ott.util.KstDateTime;
 import lombok.AllArgsConstructor;
@@ -10,8 +9,6 @@ import lombok.Setter;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.List;
 
 @Getter
@@ -62,7 +59,7 @@ public class ProductListResponseDto {
         @JsonProperty("promotion_end_at")
         private final KstDateTime promotionEndAt;
 
-        @JsonProperty("is_promotion")
+        @JsonProperty("is_on_promotion")
         private final boolean promotion;
 
         @JsonProperty("scraped")
@@ -83,10 +80,10 @@ public class ProductListResponseDto {
             this.variantName = variantName;
             this.imageUrl = imageUrl;
             this.originalPrice = originalPrice;
-            this.discountPrice = discountPrice;
-            this.discountRate = discountRate;
-            this.promotionStartAt = promotionStartAt != null ? new KstDateTime(promotionStartAt) : null;
-            this.promotionEndAt = promotionEndAt != null ? new KstDateTime(promotionEndAt) : null;
+            this.discountPrice = promotion ? discountPrice : null;
+            this.discountRate = promotion ? discountRate : null;
+            this.promotionStartAt = promotion ? (promotionStartAt != null ? new KstDateTime(promotionStartAt) : null) : null;
+            this.promotionEndAt = promotion ? (promotionEndAt != null ? new KstDateTime(promotionEndAt) : null) : null;
             this.availableQuantity = availableQuantity;
             this.promotion = promotion;
             this.scraped = scraped;


### PR DESCRIPTION

## ✏️ PR 내용
### fix: 상품 목록 보이지 않는 것 해결

### 설명
- 기존 특가 상품과 연결되어 있는 상품이 특가 상태가 끝나도 일반 상품에서 보이지 않는 현상 발생
- 코드 확인 후 variant과 promotion이 연결되어 있는 것을 특가 상태로 인식하고 있는 것을 확인(is_on_promotion이 아닌 관계 형성을 특가 상태로 판단)
- 해당 내용을 is_on_promotion으로 판단하도록 로직 변경
- 이후 특가 상품이 아닐 때도 promotion에서 활용하는 값들이 같이 넘어감(할인가 등)
- promotion 상태를 확인하여 특가 상태가 아니라면 관련 데이터 넘기지 않도록 설정