### PR TITLE
fix: 주문 내역 이미지 매핑 오류 해결

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/orderItem/infrastructure/repositoryImpl/OrderItemQueryRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/orderItem/infrastructure/repositoryImpl/OrderItemQueryRepositoryImpl.java
@@ -37,7 +37,7 @@ public class OrderItemQueryRepositoryImpl implements OrderItemQueryRepository {
                 .from(orderItem)
                 .join(productVariant).on(orderItem.productVariantEntity.id.eq(productVariant.id))
                 .leftJoin(productImage).on(
-                        productImage.variantEntity.id.eq(productVariant.productEntity.id)
+                        productImage.variantEntity.id.eq(productVariant.id)
                                 .and(productImage.sequence.eq(1))
                 )
                 .where(orderItem.productOrderEntity.id.in(orderIds))


### PR DESCRIPTION

## ✏️ PR 내용
### fix: 주문 내역 이미지 매핑 오류 해결

### 설명
- queryDSL로 변경하며 variant_id와 매핑되어야 하는 로직이 product로 매핑 되어 있음
- product_id를 variant_id로 변경