### PR TITLE
fix: 주문 내역 상세 조회 이미지 매핑 오류 해결

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/productOrder/application/serviceimpl/ProductOrderServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/productOrder/application/serviceimpl/ProductOrderServiceImpl.java
@@ -319,7 +319,7 @@ public class ProductOrderServiceImpl implements ProductOrderService {
     private List<MyProductOrderResponseDto.ProductInfo> buildProductInfoList(List<OrderItem> items) {
         return items.stream().map(item -> {
             ProductVariant variant = productVariantRepository.findById(item.getVariantsId());
-            ProductImage image = productImageRepository.findMainImage(variant.getProductId());
+            ProductImage image = productImageRepository.findMainImage(variant.getId());
 
             return new MyProductOrderResponseDto.ProductInfo(
                     item.getId(),


### PR DESCRIPTION

## ✏️ PR 내용
### fix: 주문 내역 상세 조회 이미지 매핑 오류 해결

### 설명
- 주문 상세 내역 조회에서 이미지 매핑 정합성 오류 해결
- variant_id와 매핑되어야 하는데 코드 리팩토링으로 product_id와 매핑으로 변경
- product_id -> variant_id로 변경