### PR TITLE
feat: 결제 후 주문/주문상품/상품 상태 변경을 이벤트 기반 비동기 처리로 변경

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/global/config/AsyncConfig.java
+++ b/src/main/java/com/kakaotech/ott/ott/global/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.kakaotech.ott.ott.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("event-payment-async-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/payment/application/event/PaymentCompletedEvent.java
+++ b/src/main/java/com/kakaotech/ott/ott/payment/application/event/PaymentCompletedEvent.java
@@ -1,0 +1,14 @@
+package com.kakaotech.ott.ott.payment.application.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class PaymentCompletedEvent {
+
+    private final Long orderId;
+    private final Long userId;
+    private final int usedPoint;
+
+}

--- a/src/main/java/com/kakaotech/ott/ott/payment/application/event/PaymentEventHandler.java
+++ b/src/main/java/com/kakaotech/ott/ott/payment/application/event/PaymentEventHandler.java
@@ -1,0 +1,56 @@
+package com.kakaotech.ott.ott.payment.application.event;
+
+import com.kakaotech.ott.ott.orderItem.domain.model.OrderItem;
+import com.kakaotech.ott.ott.orderItem.domain.model.OrderItemStatus;
+import com.kakaotech.ott.ott.orderItem.domain.repository.OrderItemRepository;
+import com.kakaotech.ott.ott.product.domain.model.ProductPromotion;
+import com.kakaotech.ott.ott.product.domain.model.ProductVariant;
+import com.kakaotech.ott.ott.product.domain.repository.ProductPromotionRepository;
+import com.kakaotech.ott.ott.product.domain.repository.ProductVariantRepository;
+import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrder;
+import com.kakaotech.ott.ott.productOrder.domain.repository.ProductOrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentEventHandler {
+
+    private final ProductOrderRepository productOrderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final ProductVariantRepository productVariantRepository;
+    private final ProductPromotionRepository productPromotionRepository;
+
+    @Async
+    @EventListener
+    @Transactional
+    public void handlePaymentCompleted(PaymentCompletedEvent event) {
+        ProductOrder order = productOrderRepository.findById(event.getOrderId());
+        order.pay();
+
+        List<OrderItem> items = orderItemRepository.findByProductOrderId(order.getId());
+        for (OrderItem item : items) {
+            if (item.getPromotionId() != null) {
+                ProductPromotion promo = productPromotionRepository.findById(item.getPromotionId());
+                promo.confirmPromotionSale(item.getQuantity());
+                productPromotionRepository.update(promo);
+            } else {
+                ProductVariant variant = productVariantRepository.findById(item.getVariantsId());
+                variant.confirmSale(item.getQuantity());
+                productVariantRepository.update(variant);
+            }
+            if (item.getStatus().equals(OrderItemStatus.PENDING)) {
+                item.pay();
+            }
+        }
+
+        productOrderRepository.paymentOrder(order);
+        orderItemRepository.payOrderItem(items);
+    }
+}
+

--- a/src/main/java/com/kakaotech/ott/ott/payment/application/serviceImpl/PaymentServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/payment/application/serviceImpl/PaymentServiceImpl.java
@@ -1,9 +1,6 @@
 package com.kakaotech.ott.ott.payment.application.serviceImpl;
 
-import com.kakaotech.ott.ott.global.exception.CustomException;
-import com.kakaotech.ott.ott.global.exception.ErrorCode;
 import com.kakaotech.ott.ott.orderItem.domain.model.OrderItem;
-import com.kakaotech.ott.ott.orderItem.domain.model.OrderItemStatus;
 import com.kakaotech.ott.ott.orderItem.domain.model.RefundReason;
 import com.kakaotech.ott.ott.orderItem.domain.repository.OrderItemRepository;
 import com.kakaotech.ott.ott.payment.application.event.PaymentCompletedEvent;
@@ -16,17 +13,9 @@ import com.kakaotech.ott.ott.payment.presentation.dto.request.PaymentRequestDto;
 import com.kakaotech.ott.ott.payment.presentation.dto.request.RefundRequestDto;
 import com.kakaotech.ott.ott.payment.presentation.dto.response.PaymentResponseDto;
 import com.kakaotech.ott.ott.payment.presentation.dto.response.RefundResponseDto;
-import com.kakaotech.ott.ott.pointHistory.domain.model.PointActionReason;
-import com.kakaotech.ott.ott.pointHistory.domain.model.PointActionType;
 import com.kakaotech.ott.ott.pointHistory.domain.model.PointHistory;
 import com.kakaotech.ott.ott.pointHistory.domain.repository.PointHistoryRepository;
-import com.kakaotech.ott.ott.product.domain.model.Product;
-import com.kakaotech.ott.ott.product.domain.model.ProductPromotion;
-import com.kakaotech.ott.ott.product.domain.model.ProductVariant;
-import com.kakaotech.ott.ott.product.domain.repository.ProductPromotionRepository;
-import com.kakaotech.ott.ott.product.domain.repository.ProductVariantRepository;
 import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrder;
-import com.kakaotech.ott.ott.productOrder.domain.model.ProductOrderStatus;
 import com.kakaotech.ott.ott.productOrder.domain.repository.ProductOrderRepository;
 import com.kakaotech.ott.ott.user.domain.model.User;
 import com.kakaotech.ott.ott.user.domain.repository.UserRepository;
@@ -49,69 +38,7 @@ public class PaymentServiceImpl implements PaymentService {
     private final ProductOrderRepository productOrderRepository;
     private final PointHistoryRepository pointHistoryRepository;
     private final OrderItemRepository orderItemRepository;
-    private final ProductPromotionRepository productPromotionRepository;
-    private final ProductVariantRepository productVariantRepository;
     private final PaymentEventHandler paymentEventHandler;
-
-//    @Override
-//    @Transactional
-//    public PaymentResponseDto createPayment(PaymentRequestDto paymentRequestDto, Long userId, Long orderId) {
-//
-//        User user = userRepository.findById(userId);
-//
-//        PointHistory pointHistory = pointHistoryRepository.findLatestPointHistoryByUserId(userId);
-//
-//        if (pointHistory.getBalanceAfter() < paymentRequestDto.getPoint()) {
-//            throw new CustomException(ErrorCode.INSUFFICIENT_POINT_BALANCE);
-//        }
-//
-//        ProductOrder productOrder = productOrderRepository.findByIdAndUserIdToPayment(orderId, userId);
-//
-//        if (paymentRequestDto.getPoint() < productOrder.getSubtotalAmount() - productOrder.getDiscountAmount()) {
-//            throw new CustomException(ErrorCode.PAYMENT_POINT_BALANCE);
-//        }
-//
-//        int afterPaymentPoint = pointHistory.getBalanceAfter() - paymentRequestDto.getPoint();
-//
-//        PointHistory afterPointHistory = PointHistory.createPointHistory(userId, paymentRequestDto.getPoint(),
-//                afterPaymentPoint, PointActionType.DEDUCT, PointActionReason.PRODUCT_PURCHASE);
-//
-//        if (productOrder.getStatus().equals(ProductOrderStatus.PAID)) {
-//
-//            throw new CustomException(ErrorCode.ALREADY_PAID);
-//        }
-//
-//        productOrder.pay();
-//        productOrderRepository.paymentOrder(productOrder);
-//
-//        Payment payment = Payment.createPayment(orderId, PaymentMethod.POINT, paymentRequestDto.getPoint());
-//
-//        Payment savedPayment = paymentRepository.save(payment, user);
-//
-//        PointHistory savedPointHistory = pointHistoryRepository.save(afterPointHistory, user);
-//
-//        List<OrderItem> orderItemList = orderItemRepository.findByProductOrderId(productOrder.getId());
-//
-//        for(OrderItem orderItem : orderItemList) {
-//            if (orderItem.getPromotionId() != null) {
-//                ProductPromotion productPromotion = productPromotionRepository.findById(orderItem.getPromotionId());
-//                productPromotion.confirmPromotionSale(orderItem.getQuantity());
-//                productPromotionRepository.update(productPromotion);
-//
-//            } else {
-//                ProductVariant productVariant = productVariantRepository.findById(orderItem.getVariantsId());
-//                productVariant.confirmSale(orderItem.getQuantity());
-//                productVariantRepository.update(productVariant);
-//            }
-//
-//            if (orderItem.getStatus().equals(OrderItemStatus.PENDING))
-//                orderItem.pay();
-//        }
-//
-//        orderItemRepository.payOrderItem(orderItemList);
-//
-//        return new PaymentResponseDto(savedPointHistory.getId(), productOrder.getId(), savedPayment.getPaymentAmount(), new KstDateTime(savedPayment.getPaidAt()));
-//    }
 
     @Override
     @Transactional

--- a/src/main/java/com/kakaotech/ott/ott/pointHistory/domain/model/PointHistory.java
+++ b/src/main/java/com/kakaotech/ott/ott/pointHistory/domain/model/PointHistory.java
@@ -1,5 +1,7 @@
 package com.kakaotech.ott.ott.pointHistory.domain.model;
 
+import com.kakaotech.ott.ott.global.exception.CustomException;
+import com.kakaotech.ott.ott.global.exception.ErrorCode;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -30,5 +32,13 @@ public class PointHistory {
                 .type(type)
                 .description(description)
                 .build();
+    }
+
+    public PointHistory deduct(int amount) {
+        if (this.getBalanceAfter() < amount)
+            throw new CustomException(ErrorCode.INSUFFICIENT_POINT_BALANCE);
+
+        return createPointHistory(this.userId, amount, this.getBalanceAfter() - amount,
+                PointActionType.DEDUCT, PointActionReason.PRODUCT_PURCHASE);
     }
 }


### PR DESCRIPTION

## ✏️ PR 내용
### feat: 결제 후 주문/주문상품/상품 상태 변경을 이벤트 기반 비동기 처리로 변경

### 설명
- 기존 결제 요청을 실행하게 되면 결제 생성, 포인트 내역 생성, 주문 상태 변경, 주문 상품 상태 변경, 상품 재고 변경에 대한 책임을 모두 가지고 있었음
- 해당 책임을 결제 생성, 포인트 내역 생성 후 비동기 처리로 주문/주문상품/상품에 대한 상태 처리를 진행
- 주문 당시에 재고를 미리 확보한 상황이므로 결제에 대한 상품 재고 처리나 주문 상태 처리는 비동기로 처리