### PR TITLE
Feat/eks deploy - ArgoCD GitOps 기반의 EKS 개발 dev 환경 자동 배포 파이프라인 도입

### DIFF
--- a/.github/workflows/eks-deploy.yml
+++ b/.github/workflows/eks-deploy.yml
@@ -1,0 +1,77 @@
+name: Backend CI & Update Dev Manifest
+
+on:
+  push:
+    branches:
+      - feat/dev
+
+jobs:
+  # 1. 개발용 이미지를 빌드하고 푸시하는 Job (출력(outputs) 제거)
+  build:
+    name: Build Dev Backend and Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew bootJar -x test
+
+      - name: Log in to DockerHub
+        run: echo "${{ secrets.DOCKERHUB_PAT }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
+      - name: Build & Push Docker image for dev
+        run: |
+          # Git 해시를 7자리로 줄여서 태그로 사용
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+          docker build -t luckyprice1103/onthetop-backend-dev:$SHORT_SHA .
+          docker push luckyprice1103/onthetop-backend-dev:$SHORT_SHA
+
+  # 2. dev 환경의 Manifest를 업데이트하는 Job
+  update-manifest:
+    name: Update Dev K8s Manifest
+    needs: build # 'build' Job이 성공해야 실행됩니다.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout k8s-manifests repository
+        uses: actions/checkout@v3
+        with:
+          repository: 100-hours-a-week/16-Hot6-cloud
+          ref: feat/k8s-manifests
+          token: ${{ secrets.MANIFEST_REPO_PAT }}
+          path: k8s-manifests
+      
+      - name: Install yq
+        run: sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/local/bin/yq
+
+      - name: Update image tag in dev deployment.yaml
+        run: |
+          # 이 작업에서 직접 이미지 태그를 생성합니다 (이전 작업의 출력에 의존하지 않음)
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+          IMAGE_NAME_WITH_TAG="luckyprice1103/onthetop-backend-dev:$SHORT_SHA"
+          
+          echo "Updating image to: $IMAGE_NAME_WITH_TAG"
+          
+          MANIFEST_PATH="k8s-manifests/k8s-manifests/dev/dev-backend-deployment.yaml"
+          yq e ".spec.template.spec.containers[0].image = \"$IMAGE_NAME_WITH_TAG\"" -i $MANIFEST_PATH
+
+      - name: Commit and push changes
+        run: |
+          # 이 작업에서 직접 이미지 태그를 다시 생성
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+          IMAGE_NAME_WITH_TAG="luckyprice1103/onthetop-backend-dev:$SHORT_SHA"
+
+          cd k8s-manifests
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git commit -am "Update dev image to $IMAGE_NAME_WITH_TAG"
+          git push


### PR DESCRIPTION
- dev eks deploy ->

핵심 변경 내용
기존의 복잡한 SSH 배포 스크립트를 제거하고, ArgoCD를 활용한 GitOps 방식으로 EKS 개발 환경 배포를 자동화.

feat/eks-deploy 브랜치에 코드를 푸시하면, GitHub Actions가 자동으로 새 Docker 이미지를 빌드하고 배포 설정 파일(deployment.yaml)의 이미지 태그를 업데이트합니다. 이후 ArgoCD가 이 변경을 감지하여 EKS 클러스터에 자동으로 배포를 반영.

참고 사항
워크플로우 실행을 위해 DOCKERHUB_PAT, DOCKERHUB_USERNAME, MANIFEST_REPO_PAT Secret이 필요.

ArgoCD는 100-hours-a-week/16-Hot6-cloud 레포지토리의 feat/k8s-manifests 브랜치를 추적하도록 설정되어야 합니다.(추후 수정.)