### PR TITLE
feat: 게시글, 추천 상품 조회 배치 작업 Redis counter 적용

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/global/config/SchedulingConfig.java
+++ b/src/main/java/com/kakaotech/ott/ott/global/config/SchedulingConfig.java
@@ -1,0 +1,21 @@
+package com.kakaotech.ott.ott.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig implements SchedulingConfigurer {
+
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(10);
+        scheduler.setThreadNamePrefix("scheduled-task-");
+        scheduler.initialize();
+        taskRegistrar.setTaskScheduler(scheduler);
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/global/config/ShedLockRedisConfig.java
+++ b/src/main/java/com/kakaotech/ott/ott/global/config/ShedLockRedisConfig.java
@@ -1,0 +1,19 @@
+package com.kakaotech.ott.ott.global.config;
+
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+@Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "10s")
+public class ShedLockRedisConfig {
+
+    @Bean
+    public LockProvider lockProvider(RedisConnectionFactory redisConnectionFactory) {
+        return new RedisLockProvider(redisConnectionFactory);
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/post/application/component/ViewCountAggregator.java
+++ b/src/main/java/com/kakaotech/ott/ott/post/application/component/ViewCountAggregator.java
@@ -1,61 +1,52 @@
 package com.kakaotech.ott.ott.post.application.component;
 
 import com.kakaotech.ott.ott.post.domain.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicLong;
 
 @Component
+@RequiredArgsConstructor
 public class ViewCountAggregator {
 
-    // postId -> 누적 조회수 델타
-    private final ConcurrentMap<Long, AtomicLong> cache = new ConcurrentHashMap<>( );
-
+    private final RedisTemplate<String, Object> redisTemplate;
     private final PostRepository postRepository;
 
-    public ViewCountAggregator(PostRepository postRepository) {
-        this.postRepository = postRepository;
-    }
+    private static final String POST_VIEW_COUNT_CACHE = "postViewCount";
 
     public void increment(Long postId) {
-        cache.computeIfAbsent(postId, id -> new AtomicLong()).incrementAndGet();
+        redisTemplate.opsForHash().increment(POST_VIEW_COUNT_CACHE, String.valueOf(postId), 1);
     }
 
     /**
      * 1분마다 실행:
-     * 1) 키별로 모아둔 카운터를 snapshot으로 추출
-     * 2) 원본 AtomicLong 은 0으로 리셋
-     * 3) snapshot을 한 건씩 DB에 반영(update view_count = view_count + delta)
+     * 1) Redis에서 Snapshot 가져옴
+     * 2) Redis 값 제거
+     * 3) DB 반영
      */
     @Scheduled(fixedDelay = 60_000)
     @SchedulerLock(name = "flush-view-counts", lockAtMostFor = "PT59S")
     @Transactional
     public void flush() {
-        if (cache.isEmpty()) {
-            return;
-        }
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries(POST_VIEW_COUNT_CACHE);
 
-        // 1) snapshot & reset
-        Map<Long, Long> toUpdate = new HashMap<>();
-        cache.forEach((postId, counter) -> {
-            long delta = counter.getAndSet(0);
+        if (entries.isEmpty()) return;
+
+        entries.forEach((postIdObj, countObj) -> {
+            Long postId = Long.parseLong(postIdObj.toString());
+            Long delta = Long.parseLong(countObj.toString());
+
             if (delta > 0) {
-                toUpdate.put(postId, delta);
-            } else {
-                cache.remove(postId, counter);  // 조회가 한 번도 없는 postId는 제거
+                postRepository.incrementViewCount(postId, delta);
             }
         });
 
-        // 2) DB에 배치 반영
-        toUpdate.forEach((postId, delta) -> {
-            postRepository.incrementViewCount(postId, delta);
-        });
+        // flush 후 초기화
+        redisTemplate.delete(POST_VIEW_COUNT_CACHE);
     }
 }

--- a/src/main/java/com/kakaotech/ott/ott/recommendProduct/application/component/ClickCountAggregator.java
+++ b/src/main/java/com/kakaotech/ott/ott/recommendProduct/application/component/ClickCountAggregator.java
@@ -1,62 +1,52 @@
 package com.kakaotech.ott.ott.recommendProduct.application.component;
 
 import com.kakaotech.ott.ott.recommendProduct.domain.repository.DeskProductRepository;
+import lombok.RequiredArgsConstructor;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicLong;
 
 @Component
+@RequiredArgsConstructor
 public class ClickCountAggregator {
-    // postId -> 누적 조회수 델타
-    private final ConcurrentMap<Long, AtomicLong> cache = new ConcurrentHashMap<>( );
 
+    private final RedisTemplate<String, Object> redisTemplate;
     private final DeskProductRepository deskProductRepository;
 
-    public ClickCountAggregator(DeskProductRepository deskProductRepository) {
-        this.deskProductRepository = deskProductRepository;
-    }
+    private static final String PRODUCT_CLICK_COUNT_CACHE = "productClickCount";
 
     public void increment(Long deskProductId) {
-        System.out.println("[increment] 호출됨 - productId = " + deskProductId);
-
-        cache.computeIfAbsent(deskProductId, id -> new AtomicLong()).incrementAndGet();
+        redisTemplate.opsForHash().increment(PRODUCT_CLICK_COUNT_CACHE, String.valueOf(deskProductId), 1);
     }
 
     /**
      * 1분마다 실행:
-     * 1) 키별로 모아둔 카운터를 snapshot으로 추출
-     * 2) 원본 AtomicLong 은 0으로 리셋
-     * 3) snapshot을 한 건씩 DB에 반영(update click_count = click_count + delta)
+     * 1) Redis에서 Snapshot 가져옴
+     * 2) Redis 값 제거
+     * 3) DB 반영
      */
     @Scheduled(fixedDelay = 60_000)
     @SchedulerLock(name = "flush-click-counts", lockAtMostFor = "PT59S")
     @Transactional
     public void flush() {
-        if (cache.isEmpty()) {
-            return;
-        }
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries(PRODUCT_CLICK_COUNT_CACHE);
 
-        // 1) snapshot & reset
-        Map<Long, Long> toUpdate = new HashMap<>();
-        cache.forEach((deskProductId, counter) -> {
-            long delta = counter.getAndSet(0);
+        if (entries.isEmpty()) return;
+
+        entries.forEach((deskIdObj, countObj) -> {
+            Long deskId = Long.parseLong(deskIdObj.toString());
+            Long delta = Long.parseLong(countObj.toString());
+
             if (delta > 0) {
-                toUpdate.put(deskProductId, delta);
-            } else {
-                cache.remove(deskProductId, counter);  // 조회가 한 번도 없는 postId는 제거
+                deskProductRepository.incrementClickCount(deskId, delta);
             }
         });
 
-        // 2) DB에 배치 반영
-        toUpdate.forEach((deskProductId, delta) -> {
-            deskProductRepository.incrementClickCount(deskProductId, delta);
-        });
+        // flush 후 초기화
+        redisTemplate.delete(PRODUCT_CLICK_COUNT_CACHE);
     }
 }


### PR DESCRIPTION

## ✏️ PR 내용
### feat: 게시글, 추천 상품 조회 배치 작업 Redis counter 적용

### 설명
- 기존 게시글 및 추천 상품 조회에 대한 DB 최신화 작업은 단일 인스턴스 환경에서 적합하도록 설치
- 또한 로컬 메모리에 저장하여 DB에 최신화하기 때문에 서버가 다운되면 데이터 유실 위험 존재
- Redis Lock을 통해 멀티 인스턴스 환경에서 하나의 인스턴스만 DB에 값을 update 하도록 보장
- 로컬 메모리가 아닌 redis를 통해 서버가 다운되도 데이터 유실 보장