### PR TITLE
fix: EnableScheduling 어노테이션 제거

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/global/config/SchedulingConfig.java
+++ b/src/main/java/com/kakaotech/ott/ott/global/config/SchedulingConfig.java
@@ -7,7 +7,6 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 
 @Configuration
-@EnableScheduling
 public class SchedulingConfig implements SchedulingConfigurer {
 
     @Override


### PR DESCRIPTION

## ✏️ PR 내용
### fix: EnableScheduling 어노테이션 제거

### 설명
- Main과 중복 선언으로 인해 config에서 제거