### PR TITLE
fix: 제품 목록에서 특가 종료될 경우 중복 해결

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/product/infrastructure/repositoryImpl/ProductVariantQueryRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/product/infrastructure/repositoryImpl/ProductVariantQueryRepositoryImpl.java
@@ -13,6 +13,7 @@ import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -25,47 +26,94 @@ import java.util.List;
 public class ProductVariantQueryRepositoryImpl implements ProductVariantQueryRepository {
 
     private final JPAQueryFactory queryFactory;
-
-    private final QProductVariantEntity variant = QProductVariantEntity.productVariantEntity;
-    private final QProductEntity product = QProductEntity.productEntity;
-    private final QProductImageEntity image = QProductImageEntity.productImageEntity;
+    private final QProductVariantEntity variant    = QProductVariantEntity.productVariantEntity;
+    private final QProductEntity        product    = QProductEntity.productEntity;
+    private final QProductImageEntity   image      = QProductImageEntity.productImageEntity;
     private final QProductPromotionEntity promotion = QProductPromotionEntity.productPromotionEntity;
 
     @Override
-    public ProductListResponseDto findProductListByCursor(Long userId, ProductType productType, PromotionType promotionType, Long lastVariantId, int size) {
+    public ProductListResponseDto findProductListByCursor(
+            Long userId,
+            ProductType productType,
+            PromotionType promotionType,
+            Long lastVariantId,
+            int size
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+        List<ProductListResponseDto.Products> products = fetchProducts(now, productType, promotionType, lastVariantId, size);
+        return buildResponse(products, size);
+    }
 
-        List<ProductListResponseDto.Products> result = queryFactory
+    private List<ProductListResponseDto.Products> fetchProducts(
+            LocalDateTime now,
+            ProductType productType,
+            PromotionType promotionType,
+            Long lastVariantId,
+            int size
+    ) {
+        JPAQuery<ProductListResponseDto.Products> baseQuery = queryFactory
                 .select(productListProjection())
                 .distinct()
                 .from(variant)
                 .join(variant.productEntity, product)
-                .leftJoin(variant.images, image).on(image.sequence.eq(1))
-                .leftJoin(variant.promotions, promotion)
-                .where(buildWhereConditions(productType, promotionType, lastVariantId))
-                .groupBy(variant.id, product.id, promotion.id)
-                .orderBy(promotionType != null ?
-                        promotion.endAt.asc().nullsLast() :
-                        variant.id.desc())
+                .leftJoin(variant.images, image).on(image.sequence.eq(1));
+
+        if (promotionType != null) {
+            applyPromotionFilter(baseQuery, now, lastVariantId);
+        } else {
+            applyDefaultFilter(baseQuery, lastVariantId);
+        }
+
+        return baseQuery
                 .limit(size)
                 .fetch();
+    }
 
-        boolean hasNext = result.size() == size;
-        Long nextLastVariantId = hasNext ? result.get(result.size() - 1).getVariantId() : null;
+    private void applyPromotionFilter(JPAQuery<ProductListResponseDto.Products> query,
+                                      LocalDateTime now,
+                                      Long lastVariantId) {
+        query
+                .innerJoin(variant.promotions, promotion)
+                .on(
+                        promotion.status.in(PromotionStatus.ACTIVE, PromotionStatus.SOLD_OUT)
+                                .and(promotion.endAt.after(now))
+                )
+                .where(
+                        variant.isOnPromotion.eq(true),
+                        variant.id.lt(lastVariantId)
+                )
+                .orderBy(promotion.endAt.asc().nullsLast());
+    }
+
+    private void applyDefaultFilter(JPAQuery<ProductListResponseDto.Products> query,
+                                    Long lastVariantId) {
+        query
+                .where(
+                        variant.isOnPromotion.eq(false),
+                        variant.id.lt(lastVariantId)
+                )
+                .orderBy(variant.id.desc());
+    }
+
+    private ProductListResponseDto buildResponse(List<ProductListResponseDto.Products> list, int size) {
+        boolean hasNext = list.size() == size;
+        Long nextLastId = hasNext ? list.get(list.size() - 1).getVariantId() : null;
 
         ProductListResponseDto.Pagination pagination = ProductListResponseDto.Pagination.builder()
                 .size(size)
-                .lastVariantId(nextLastVariantId)
+                .lastVariantId(nextLastId)
                 .hasNext(hasNext)
                 .build();
 
         return ProductListResponseDto.builder()
-                .products(result)
+                .products(list)
                 .pagination(pagination)
                 .build();
     }
 
     private ConstructorExpression<ProductListResponseDto.Products> productListProjection() {
-        return Projections.constructor(ProductListResponseDto.Products.class,
+        return Projections.constructor(
+                ProductListResponseDto.Products.class,
                 product.id,
                 product.name,
                 product.type.stringValue(),
@@ -77,38 +125,12 @@ public class ProductVariantQueryRepositoryImpl implements ProductVariantQueryRep
                 promotion.rate,
                 promotion.startAt,
                 promotion.endAt,
-                variant.totalQuantity.subtract(variant.reservedQuantity).subtract(variant.soldQuantity),
+                variant.totalQuantity
+                        .subtract(variant.reservedQuantity)
+                        .subtract(variant.soldQuantity),
                 variant.isOnPromotion,
                 Expressions.constant(false),
                 product.createdAt
         );
-    }
-
-    private BooleanExpression[] buildWhereConditions(ProductType productType,
-                                                     PromotionType promotionType,
-                                                     Long lastVariantId) {
-        return new BooleanExpression[]{
-                productTypeEq(productType),
-                promotionTypeConditional(promotionType),
-                lastVariantIdLt(lastVariantId)
-        };
-    }
-
-    private BooleanExpression productTypeEq(ProductType productType) {
-        return productType != null ? product.type.eq(productType) : null;
-    }
-
-    private BooleanExpression promotionTypeConditional(PromotionType promotionType) {
-        if (promotionType != null) {
-            return variant.isOnPromotion.eq(true)
-                    .and(promotion.status.in(PromotionStatus.ACTIVE, PromotionStatus.SOLD_OUT))
-                    .and(promotion.endAt.after(LocalDateTime.now()));
-        } else {
-            return variant.isOnPromotion.eq(false); // 일반 상품만 조회
-        }
-    }
-
-    private BooleanExpression lastVariantIdLt(Long lastVariantId) {
-        return lastVariantId != null ? variant.id.lt(lastVariantId) : null;
     }
 }


### PR DESCRIPTION

## ✏️ PR 내용
### fix: 제품 목록에서 특가 종료될 경우 중복 해결

### 설명
- variant와 promotion이 1:N 관계로 Left join을 실행했을 때 여러 개의 variant_id값을 가진 row가 중복으로 들어올 수 있음
- groupBy에서 역시 variant_id, promotion_id로 묶었기 때문에 variant_id가 같은 row 중복으로 조회