### PR TITLE
Feat/like redis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,8 +79,8 @@ dependencies {
 	implementation 'net.javacrumbs.shedlock:shedlock-spring:6.3.1'
 	implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:6.3.1'
 
-	// redis client
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// redisson lock
+	implementation 'org.redisson:redisson-spring-boot-starter:3.50.0'
 
 	// Jackson
 	implementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/src/main/java/com/kakaotech/ott/ott/batch/application/component/BatchExecutor.java
+++ b/src/main/java/com/kakaotech/ott/ott/batch/application/component/BatchExecutor.java
@@ -16,15 +16,15 @@ public class BatchExecutor {
     public void execute(String jobName, Runnable action) {
         LocalDateTime scheduleAt = LocalDateTime.now().withSecond(0).withNano(0);
         BatchJobLog log = BatchJobLog.createBatchJobLog(jobName, scheduleAt);
-        log = batchJobLogRepository.save(log);
+        BatchJobLog savedLog = batchJobLogRepository.save(log);
 
         try {
             action.run();
-            log.markSuccess();
+            savedLog.markSuccess();
         } catch (Exception e) {
-            log.markFailed(e.getMessage());
+            savedLog.markFailed(e.getMessage());
         } finally {
-            batchJobLogRepository.update(log);
+            batchJobLogRepository.update(savedLog);
         }
     }
 

--- a/src/main/java/com/kakaotech/ott/ott/global/config/RedisConfig.java
+++ b/src/main/java/com/kakaotech/ott/ott/global/config/RedisConfig.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.kakaotech.ott.ott.like.infrastructure.sync.LikeEvent;
+import com.kakaotech.ott.ott.scrap.infrastructure.sycn.ScrapEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,6 +13,7 @@ import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCust
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -82,6 +85,47 @@ public class RedisConfig {
 
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new StringRedisSerializer());
+
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    @Primary
+    @Bean(name = "stringRedisTemplate")
+    public RedisTemplate<String, String> stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        StringRedisSerializer stringSerializer = new StringRedisSerializer();
+        template.setKeySerializer(stringSerializer);
+        template.setValueSerializer(stringSerializer);
+        template.setHashKeySerializer(stringSerializer);
+        template.setHashValueSerializer(stringSerializer);
+        template.setDefaultSerializer(stringSerializer);
+
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    @Bean(name = "likeEventRedisTemplate")
+    public RedisTemplate<String, LikeEvent> likeEventRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, LikeEvent> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    @Bean(name = "scrapEventRedisTemplate")
+    public RedisTemplate<String, ScrapEvent> scrapEventRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, ScrapEvent> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         template.afterPropertiesSet();
         return template;

--- a/src/main/java/com/kakaotech/ott/ott/global/config/RedisStreamConsumerConfig.java
+++ b/src/main/java/com/kakaotech/ott/ott/global/config/RedisStreamConsumerConfig.java
@@ -1,0 +1,208 @@
+package com.kakaotech.ott.ott.global.config;
+
+import com.kakaotech.ott.ott.like.infrastructure.sync.LikeSyncService;
+import com.kakaotech.ott.ott.scrap.infrastructure.sycn.ScrapSyncService;
+import com.kakaotech.ott.ott.util.scheduler.LikeRedisKey;
+import com.kakaotech.ott.ott.util.scheduler.ScrapRedisKey;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.stream.*;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer.StreamMessageListenerContainerOptions;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class RedisStreamConsumerConfig {
+
+    private static final String LIKE_STREAM_KEY = LikeRedisKey.LIKE_STREAM_KEY;
+
+    private static final String LIKE_GROUP = "likeGroup";
+
+    private static final Duration POLL_TIMEOUT  = Duration.ofSeconds(1);
+    private static final int BATCH_SIZE         = 10;
+
+    private final RedisConnectionFactory connectionFactory;
+    private final StringRedisTemplate     redisTemplate;
+    private final LikeSyncService         likeSyncService;
+    private final ScrapSyncService        scrapSyncService;
+
+    @Bean(destroyMethod = "stop")
+    public StreamMessageListenerContainer<String, MapRecord<String,String,String>>
+    likeListenerContainer() {
+        // 1) Consumer Group 생성(이미 있으면 예외 무시)
+        try {
+            redisTemplate.opsForStream().createGroup(LIKE_STREAM_KEY, LIKE_GROUP);
+        } catch (Exception ignored) {}
+
+        // 2) Container 옵션
+        StreamMessageListenerContainerOptions<String, MapRecord<String,String,String>> opts =
+                StreamMessageListenerContainerOptions
+                        .<String, MapRecord<String,String,String>>builder()
+                        .pollTimeout(POLL_TIMEOUT)
+                        .batchSize(BATCH_SIZE)
+                        .build();
+
+        // 3) Container 생성
+        var container = StreamMessageListenerContainer
+                .create(connectionFactory, opts);
+
+        // 4) 메시지 수신 등록
+        String consumerName = "likeConsumer-" + UUID.randomUUID().toString();
+        container.receive(
+                Consumer.from(LIKE_GROUP, consumerName),
+                StreamOffset.create(LIKE_STREAM_KEY, ReadOffset.lastConsumed()),
+                this::handleMapRecord
+        );
+
+        container.start();
+        log.info("▶ Stream listener started: group='{}', consumer='{}'", LIKE_GROUP, consumerName);
+        return container;
+    }
+
+    private void handleMapRecord(MapRecord<String,String,String> record) {
+        Map<String,String> m = record.getValue();
+        String sUser   = m.get("userId");
+        String sPost   = m.get("postId");
+        String action  = m.get("action");
+
+        if (sUser == null || sPost == null || action == null) {
+            log.warn("▶ Skip invalid record: {}", record);
+            ackAndDelete(LIKE_STREAM_KEY, LIKE_GROUP, record.getId());
+            return;
+        }
+
+        long userId, postId;
+        try {
+            userId = Long.parseLong(sUser);
+            postId = Long.parseLong(sPost);
+        } catch (NumberFormatException ex) {
+            log.warn("▶ Skip malformed IDs: {}", record, ex);
+            ackAndDelete(LIKE_STREAM_KEY, LIKE_GROUP, record.getId());
+            return;
+        }
+
+        // 단일 레코드도 batch 파라미터 형태로 만들어서 넘긴다
+        boolean isLike = "like".equals(action);
+        String eventId = record.getId().toString();
+
+        List<Object[]> upsertParams = List.<Object[]>of(
+                new Object[]{ userId, postId, isLike, isLike, eventId }
+        );
+        Map<Long,Long> deltas = Map.of(postId, isLike ? 1L : -1L);
+
+        try {
+            // 5) 기존 syncBatchWithVersion 호출
+            likeSyncService.syncBatchWithVersion(upsertParams, deltas);
+            ackAndDelete(LIKE_STREAM_KEY, LIKE_GROUP, record.getId());
+        } catch (Exception ex) {
+            log.error("▶ syncBatchWithVersion failed for {}, will retry later", record.getId(), ex);
+            // 필요하면 PEL에 남겨두고 리트라이 스케줄러가 처리하게…
+        }
+    }
+
+    @Bean(destroyMethod = "stop")
+    public StreamMessageListenerContainer<String, MapRecord<String, String, String>>
+    scrapPostListenerContainer() {
+        return createScrapContainer(
+                ScrapRedisKey.SCRAP_STREAM_KEY_POST,
+                "scrapPostGroup"
+        );
+    }
+
+    @Bean(destroyMethod = "stop")
+    public StreamMessageListenerContainer<String, MapRecord<String, String, String>>
+    scrapProductListenerContainer() {
+        return createScrapContainer(
+                ScrapRedisKey.SCRAP_STREAM_KEY_PRODUCT,
+                "scrapProductGroup"
+        );
+    }
+
+    @Bean(destroyMethod = "stop")
+    public StreamMessageListenerContainer<String, MapRecord<String, String, String>>
+    scrapServiceProductListenerContainer() {
+        return createScrapContainer(
+                ScrapRedisKey.SCRAP_STREAM_KEY_SERVICE_PRODUCT,
+                "scrapServiceProductGroup"
+        );
+    }
+
+    private StreamMessageListenerContainer<String, MapRecord<String, String, String>> createScrapContainer(
+            String streamKey, String group) {
+        try {
+            redisTemplate.opsForStream().createGroup(streamKey, group);
+        } catch (Exception ignored) {}
+
+        var opts = StreamMessageListenerContainerOptions
+                .<String, MapRecord<String, String, String>>builder()
+                .pollTimeout(POLL_TIMEOUT)
+                .batchSize(BATCH_SIZE)
+                .build();
+
+        var container = StreamMessageListenerContainer
+                .create(connectionFactory, opts);
+
+        String consumer = group + "-" + UUID.randomUUID();
+        container.receive(
+                Consumer.from(group, consumer),
+                StreamOffset.create(streamKey, ReadOffset.lastConsumed()),
+                record -> handleScrapEvent(record, streamKey, group)
+        );
+        container.start();
+        log.info("▶ Scrap listener started: stream='{}', group='{}', consumer='{}'",
+                streamKey, group, consumer);
+        return container;
+    }
+
+    private void handleScrapEvent(MapRecord<String, String, String> record, String streamKey, String group) {
+        Map<String, String> map = record.getValue();
+        String sUser    = map.get("userId");
+        String sTarget  = map.get("targetId");
+        String type     = map.get("type");
+        String action   = map.get("action");
+
+        if (sUser == null || sTarget == null || type == null || action == null) {
+            log.warn("▶ Skip invalid scrap record: {}", record);
+            ackAndDelete(streamKey, group, record.getId());
+            return;
+        }
+
+        long userId, targetId;
+        try {
+            userId = Long.parseLong(sUser);
+            targetId = Long.parseLong(sTarget);
+        } catch (NumberFormatException ex) {
+            log.warn("▶ Skip malformed IDs in scrap record: {}", record, ex);
+            ackAndDelete(streamKey, group, record.getId());
+            return;
+        }
+
+        boolean isScrap = "scrap".equals(action);
+        String eventId = record.getId().toString();
+
+        List<Object[]> upsertParams =
+                List.<Object[]>of(new Object[]{userId, type, targetId, isScrap, eventId});
+        Map<String, Long> deltas = Map.of(targetId + ":" + type, isScrap ? 1L : -1L);
+
+        try {
+            scrapSyncService.syncBatchWithVersion(upsertParams, deltas);
+            ackAndDelete(streamKey, group, record.getId());
+        } catch (Exception ex) {
+            log.error("▶ Like sync failed for {}, will retry later", record.getId(), ex);
+        }
+    }
+    private void ackAndDelete(String streamKey, String group, RecordId id) {
+        redisTemplate.opsForStream().acknowledge(streamKey, group, id);
+        redisTemplate.opsForStream().delete(streamKey, id);
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/global/config/StreamRedisConfig.java
+++ b/src/main/java/com/kakaotech/ott/ott/global/config/StreamRedisConfig.java
@@ -1,0 +1,19 @@
+package com.kakaotech.ott.ott.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+@RequiredArgsConstructor
+public class StreamRedisConfig {
+
+    private final RedisConnectionFactory redisConnectionFactory;
+
+    @Bean
+    public StringRedisTemplate streamStringRedisTemplate() {
+        return new StringRedisTemplate(redisConnectionFactory);
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/like/application/service/LikeService.java
+++ b/src/main/java/com/kakaotech/ott/ott/like/application/service/LikeService.java
@@ -4,7 +4,5 @@ import com.kakaotech.ott.ott.like.presentation.dto.request.LikeRequestDto;
 
 public interface LikeService {
 
-    void likePost(Long userId, LikeRequestDto likeRequestDto);
-
-    void unlikePost(Long userId, LikeRequestDto likeRequestDto);
+    void toggleLike(Long userId, LikeRequestDto likeRequestDto);
 }

--- a/src/main/java/com/kakaotech/ott/ott/like/domain/model/Like.java
+++ b/src/main/java/com/kakaotech/ott/ott/like/domain/model/Like.java
@@ -17,12 +17,17 @@ public class Like {
 
     private Boolean isActive;
 
+    private String lastEventId;
+
     private LocalDateTime createdAt;
 
-    public static Like createLike(Long userId, Long postId) {
+    private LocalDateTime updatedAt;
+
+    public static Like createLike(Long userId, Long postId, String lastEventId) {
         return Like.builder()
                 .userId(userId)
                 .postId(postId)
+                .lastEventId(lastEventId)
                 .isActive(true)  // 기본 활성화
                 .build();
     }

--- a/src/main/java/com/kakaotech/ott/ott/like/domain/repository/LikeJpaRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/like/domain/repository/LikeJpaRepository.java
@@ -11,8 +11,16 @@ import java.util.List;
 
 public interface LikeJpaRepository extends JpaRepository<LikeEntity, Long> {
 
+    @Query("""
+    SELECT CASE WHEN COUNT(l) > 0 THEN true ELSE false END
+    FROM LikeEntity l
+    WHERE l.userEntity.id = :userId
+      AND l.postEntity.id = :postId
+      AND l.isActive = true
+""")
+    boolean existsActiveByUserIdAndPostId(@Param("userId") Long userId,
+                                          @Param("postId") Long postId);
 
-    boolean existsByUserEntityIdAndPostEntityId(Long userId, Long postId);
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM LikeEntity l WHERE l.userEntity.id = :userId AND l.postEntity.id = :postId")

--- a/src/main/java/com/kakaotech/ott/ott/like/domain/repository/LikeRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/like/domain/repository/LikeRepository.java
@@ -1,15 +1,11 @@
 package com.kakaotech.ott.ott.like.domain.repository;
 
-import com.kakaotech.ott.ott.like.domain.model.Like;
-
 import java.util.List;
 import java.util.Set;
 
 public interface LikeRepository {
 
     void deleteByUserEntityIdAndTargetId(Long userId, Long postId);
-
-    Like save(Like like);
 
     boolean existsByUserIdAndPostId(Long userId, Long postId);
 

--- a/src/main/java/com/kakaotech/ott/ott/like/infrastructure/entity/LikeEntity.java
+++ b/src/main/java/com/kakaotech/ott/ott/like/infrastructure/entity/LikeEntity.java
@@ -3,6 +3,7 @@ package com.kakaotech.ott.ott.like.infrastructure.entity;
 import com.kakaotech.ott.ott.like.domain.model.Like;
 import com.kakaotech.ott.ott.post.infrastructure.entity.PostEntity;
 import com.kakaotech.ott.ott.user.infrastructure.entity.UserEntity;
+import com.kakaotech.ott.ott.util.AuditEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -22,7 +23,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class LikeEntity {
+public class LikeEntity extends AuditEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,9 +40,8 @@ public class LikeEntity {
     @Column(name = "is_active", nullable = false)
     private Boolean isActive;
 
-    @CreatedDate
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    @Column(name = "last_event_id", nullable = false, length = 32)
+    private String lastEventId;
 
     public Like toDomain() {
         return Like.builder()
@@ -49,7 +49,9 @@ public class LikeEntity {
                 .userId(this.userEntity.getId())
                 .postId(this.postEntity.getId())
                 .isActive(this.isActive)
-                .createdAt(this.createdAt)
+                .lastEventId(this.lastEventId)
+                .createdAt(this.getCreatedAt())
+                .updatedAt(this.getUpdatedAt())
                 .build();
     }
 
@@ -60,7 +62,7 @@ public class LikeEntity {
                 .userEntity(userEntity)
                 .postEntity(postEntity)
                 .isActive(like.getIsActive())
-                .createdAt(like.getCreatedAt())
+                .lastEventId(like.getLastEventId())
                 .build();
     }
 }

--- a/src/main/java/com/kakaotech/ott/ott/like/infrastructure/repositoryImpl/LikeRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/like/infrastructure/repositoryImpl/LikeRepositoryImpl.java
@@ -10,9 +10,10 @@ import com.kakaotech.ott.ott.post.domain.repository.PostJpaRepository;
 import com.kakaotech.ott.ott.post.infrastructure.entity.PostEntity;
 import com.kakaotech.ott.ott.user.domain.repository.UserJpaRepository;
 import com.kakaotech.ott.ott.user.infrastructure.entity.UserEntity;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
 import java.util.List;
@@ -23,32 +24,15 @@ import java.util.Set;
 public class LikeRepositoryImpl implements LikeRepository {
 
     private final LikeJpaRepository likeJpaRepository;
-    private final UserJpaRepository userJpaRepository;
-    private final PostJpaRepository postJpaRepository;
 
     @Override
-    @Transactional
     public void deleteByUserEntityIdAndTargetId(Long userId, Long postId) {
         likeJpaRepository.deleteByUserEntityIdAndTargetId(userId, postId);
     }
 
     @Override
-    @Transactional
-    public Like save(Like like) {
-
-        UserEntity userEntity = userJpaRepository.findById(like.getUserId())
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        PostEntity postEntity = postJpaRepository.findById(like.getPostId())
-                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-
-        return likeJpaRepository.save(LikeEntity.from(like, userEntity, postEntity)).toDomain();
-    }
-
-    @Override
-    @Transactional(readOnly = true)
     public boolean existsByUserIdAndPostId(Long userId, Long postId) {
-        return likeJpaRepository.existsByUserEntityIdAndPostEntityId(userId, postId);
+        return likeJpaRepository.existsActiveByUserIdAndPostId(userId, postId);
     }
 
     @Override

--- a/src/main/java/com/kakaotech/ott/ott/like/infrastructure/sync/LikeEvent.java
+++ b/src/main/java/com/kakaotech/ott/ott/like/infrastructure/sync/LikeEvent.java
@@ -1,0 +1,14 @@
+package com.kakaotech.ott.ott.like.infrastructure.sync;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class LikeEvent {
+    private Long userId;
+    private Long postId;
+    private String action;
+}

--- a/src/main/java/com/kakaotech/ott/ott/like/infrastructure/sync/LikeEventPublisher.java
+++ b/src/main/java/com/kakaotech/ott/ott/like/infrastructure/sync/LikeEventPublisher.java
@@ -1,0 +1,23 @@
+package com.kakaotech.ott.ott.like.infrastructure.sync;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.stream.ObjectRecord;
+import org.springframework.data.redis.connection.stream.StreamRecords;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LikeEventPublisher {
+
+    private static final String LIKE_STREAM_KEY = "like:stream:events";
+    private final RedisTemplate<String, LikeEvent> redisTemplate;
+
+    public void publish(LikeEvent event) {
+        ObjectRecord<String, LikeEvent> record = StreamRecords
+                .objectBacked(event)
+                .withStreamKey(LIKE_STREAM_KEY);
+
+        redisTemplate.opsForStream().add(record);
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/like/infrastructure/sync/LikeSyncService.java
+++ b/src/main/java/com/kakaotech/ott/ott/like/infrastructure/sync/LikeSyncService.java
@@ -1,0 +1,8 @@
+package com.kakaotech.ott.ott.like.infrastructure.sync;
+
+import java.util.List;
+import java.util.Map;
+
+public interface LikeSyncService {
+    void syncBatchWithVersion(List<Object[]> params, Map<Long, Long> deltas);
+}

--- a/src/main/java/com/kakaotech/ott/ott/like/infrastructure/sync/LikeSyncServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/like/infrastructure/sync/LikeSyncServiceImpl.java
@@ -1,0 +1,42 @@
+package com.kakaotech.ott.ott.like.infrastructure.sync;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class LikeSyncServiceImpl implements LikeSyncService{
+
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    @Override
+    public void syncBatchWithVersion(List<Object[]> params, Map<Long, Long> deltas) {
+        String sql = """
+        INSERT INTO likes (user_id, post_id, is_active, last_event_id)
+            VALUES (:userId, :postId, :liked, :eventId)
+            ON DUPLICATE KEY UPDATE
+              is_active     = IF(last_event_id < VALUES(last_event_id),
+                                 VALUES(is_active),
+                                 is_active),
+              last_event_id = IF(last_event_id < VALUES(last_event_id),
+                                 VALUES(last_event_id),
+                                 last_event_id)
+        """;
+
+        SqlParameterSource[] batch = params.stream()
+                .map(p -> new MapSqlParameterSource()
+                        .addValue("liked", p[2])
+                        .addValue("eventId", p[4])
+                        .addValue("userId", p[0])
+                        .addValue("postId", p[1]))
+                .toArray(SqlParameterSource[]::new);
+
+        namedParameterJdbcTemplate.batchUpdate(sql, batch);
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/like/presentation/controller/LikeController.java
+++ b/src/main/java/com/kakaotech/ott/ott/like/presentation/controller/LikeController.java
@@ -19,24 +19,14 @@ public class LikeController {
     private final LikeService likeService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse> activeLike(@AuthenticationPrincipal UserPrincipal userPrincipal,
+    public ResponseEntity<ApiResponse> toggleLike(@AuthenticationPrincipal UserPrincipal userPrincipal,
                                                   @RequestBody @Valid LikeRequestDto likeRequestDto) {
 
         Long userId = userPrincipal.getId();
 
-        likeService.likePost(userId, likeRequestDto);
+        likeService.toggleLike(userId, likeRequestDto);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("좋아요 완료", null));
     }
 
-    @DeleteMapping
-    public ResponseEntity<Void> deactiveLike(@AuthenticationPrincipal UserPrincipal userPrincipal,
-                                                  @RequestBody @Valid LikeRequestDto likeRequestDto) {
-
-        Long userId = userPrincipal.getId();
-
-        likeService.unlikePost(userId, likeRequestDto);
-
-        return ResponseEntity.noContent().build();
-    }
 }

--- a/src/main/java/com/kakaotech/ott/ott/util/scheduler/LikePendingMessageRetryScheduler.java
+++ b/src/main/java/com/kakaotech/ott/ott/util/scheduler/LikePendingMessageRetryScheduler.java
@@ -1,0 +1,98 @@
+package com.kakaotech.ott.ott.util.scheduler;
+
+import com.kakaotech.ott.ott.like.infrastructure.sync.LikeSyncService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessage;
+import org.springframework.data.redis.connection.stream.PendingMessages;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@Slf4j
+public class LikePendingMessageRetryScheduler {
+
+    private final String STREAM         = LikeRedisKey.LIKE_STREAM_KEY;
+    private final String GROUP          = "likeGroup";
+    private final String RETRY_CONSUMER = "retryConsumer";
+
+    private final StringRedisTemplate streamStringRedisTemplate;
+    private final LikeSyncService     likeSyncService;
+
+    public LikePendingMessageRetryScheduler(
+            @Qualifier("streamStringRedisTemplate") StringRedisTemplate streamStringRedisTemplate,
+            LikeSyncService likeSyncService
+    ) {
+        this.streamStringRedisTemplate = streamStringRedisTemplate;
+        this.likeSyncService = likeSyncService;
+    }
+
+    @Scheduled(fixedDelay = 60_000, initialDelay = 30_000)
+    public void retryPending() {
+        PendingMessages pending = streamStringRedisTemplate.opsForStream()
+                .pending(STREAM, GROUP, Range.unbounded(), 100);
+
+        for (PendingMessage msg : pending) {
+            if (msg.getElapsedTimeSinceLastDelivery().toMillis() < 30_000)
+                continue;
+
+            @SuppressWarnings("unchecked")
+            List<MapRecord<String, String, String>> claimed =
+                    (List<MapRecord<String, String, String>>) (List<?>)
+                            streamStringRedisTemplate.opsForStream()
+                                    .claim(
+                                            STREAM,
+                                            GROUP,
+                                            RETRY_CONSUMER,
+                                            Duration.ofMillis(1),   // ← 여기서 long + TimeUnit 대신 Duration 사용
+                                            msg.getId()             // RecordId…
+                                    );
+
+
+            if (claimed == null || claimed.isEmpty()) {
+                log.warn("⚠️ 메시지 claim 실패 또는 없음: {}", msg.getId());
+                continue;
+            }
+
+            // 1) upsert 파라미터 생성
+            List<Object[]> params = claimed.stream()
+                    .map(r -> {
+                        Map<String, String> v = r.getValue();
+                        long userId = Long.parseLong(v.get("userId"));
+                        long postId = Long.parseLong(v.get("postId"));
+                        boolean like = "like".equals(v.get("action"));
+                        String eventId = r.getId().toString();
+                        return new Object[]{userId, postId, like, like, eventId};
+                    })
+                    .collect(Collectors.toList());
+
+            // 2) 델타 계산
+            Map<Long, Long> deltas = claimed.stream()
+                    .collect(Collectors.groupingBy(
+                            r -> Long.parseLong(r.getValue().get("postId")),
+                            Collectors.summingLong(r -> "like".equals(r.getValue().get("action")) ? 1L : -1L)
+                    ));
+
+            try {
+                likeSyncService.syncBatchWithVersion(params, deltas);
+
+                RecordId[] ids = claimed.stream()
+                        .map(MapRecord::getId)
+                        .toArray(RecordId[]::new);
+                streamStringRedisTemplate.opsForStream().acknowledge(STREAM, GROUP, ids);
+                streamStringRedisTemplate.opsForStream().delete(STREAM, ids);
+            } catch (Exception e) {
+                log.error("[PendingRetry] 메시지 처리 실패: {}", msg.getId(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/util/scheduler/LikeRedisKey.java
+++ b/src/main/java/com/kakaotech/ott/ott/util/scheduler/LikeRedisKey.java
@@ -1,0 +1,10 @@
+package com.kakaotech.ott.ott.util.scheduler;
+
+public class LikeRedisKey {
+
+    public static final String LIKE_SET_PREFIX    = "like:set:post:";
+    public static final String LIKE_STREAM_KEY    = "like:stream:events";
+
+    public static String setLikeKey(Long postId)    { return LIKE_SET_PREFIX   + postId; }
+
+}

--- a/src/main/resources/application-feat.properties
+++ b/src/main/resources/application-feat.properties
@@ -12,9 +12,15 @@ DOMAIN=localhost
 SAMESITE=LAX
 SECURE=false
 
+logging.level.root=INFO
+logging.level.net.javacrumbs.shedlock=DEBUG
+
 # Redis
 REDIS_MASTER_NAME=dev-sentinel-master
 REDIS_SENTINEL_NODES=dev-sentinel.onthe-top.com:26379
 
 CACHE_DEFAULT_TTL=3600000
 REDIS_TIMEOUT=5000
+
+spring.redis.redisson.file=classpath:redisson.yaml
+

--- a/src/main/resources/db/migration/V8__likes_new_column.sql
+++ b/src/main/resources/db/migration/V8__likes_new_column.sql
@@ -1,0 +1,14 @@
+ALTER TABLE `likes`
+  ADD COLUMN `last_event_id` VARCHAR(32) NOT NULL
+    DEFAULT '0',
+  ADD COLUMN `updated_at`   TIMESTAMP    NOT NULL
+    DEFAULT CURRENT_TIMESTAMP
+    ON UPDATE CURRENT_TIMESTAMP;
+
+UPDATE `likes`
+SET
+  `last_event_id` = '0',
+  `updated_at`    = `created_at`;
+
+ALTER TABLE `likes`
+  ALTER COLUMN `last_event_id` DROP DEFAULT;


### PR DESCRIPTION
## ✏️ PR 내용
### Feat/like redis

### 설명
- 기존 like 요청 시 POST, DELETE 메서드로 호출하여 각각 다른 API 사용
- 또한 요청마다 곧바로 DB 접근하여 업데이트
- DB 부하 및 사용자 응답 속도 개선을 위해 Redis 적용
- API를 하나로 통합하여 요청 및 취소 toggle 방식으로 변경
- Redis Set으로 현재 사용자의 상태 파악(값 존재하면 활성 상태)
- 요청된 데이터는 stream을 통해 DB로 비동기 처리