### PR TITLE
feat: Scrap 요청 및 취소 시 곧바로 DB 접근 방식 대신 Redis 방식 적용

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/global/config/StreamConfig.java
+++ b/src/main/java/com/kakaotech/ott/ott/global/config/StreamConfig.java
@@ -1,0 +1,25 @@
+package com.kakaotech.ott.ott.global.config;
+
+public class StreamConfig {
+    private final String streamKey;
+    private final String group;
+    private final String retryConsumer;
+
+    public StreamConfig(String streamKey, String group, String retryConsumer) {
+        this.streamKey = streamKey;
+        this.group = group;
+        this.retryConsumer = retryConsumer;
+    }
+
+    public String getStreamKey() {
+        return streamKey;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public String getRetryConsumer() {
+        return retryConsumer;
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/global/config/StreamConfigFactory.java
+++ b/src/main/java/com/kakaotech/ott/ott/global/config/StreamConfigFactory.java
@@ -1,0 +1,36 @@
+package com.kakaotech.ott.ott.global.config;
+
+import com.kakaotech.ott.ott.util.scheduler.ScrapRedisKey;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class StreamConfigFactory {
+
+    @Bean("postStreamConfig")
+    public StreamConfig postStreamConfig() {
+        return new StreamConfig(
+                ScrapRedisKey.SCRAP_STREAM_KEY_POST,
+                "scrapPostGroup",
+                "scrapPostRetryConsumer"
+        );
+    }
+
+    @Bean("productStreamConfig")
+    public StreamConfig productStreamConfig() {
+        return new StreamConfig(
+                ScrapRedisKey.SCRAP_STREAM_KEY_PRODUCT,
+                "scrapProductGroup",
+                "scrapProductRetryConsumer"
+        );
+    }
+
+    @Bean("serviceProductStreamConfig")
+    public StreamConfig serviceProductStreamConfig() {
+        return new StreamConfig(
+                ScrapRedisKey.SCRAP_STREAM_KEY_SERVICE_PRODUCT,
+                "scrapServiceProductGroup",
+                "scrapServiceProductRetryConsumer"
+        );
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/global/exception/ErrorCode.java
+++ b/src/main/java/com/kakaotech/ott/ott/global/exception/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     // Scrap
     SCRAP_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 스크랩한 게시글입니다."),
     SCRAP_NOT_FOUND(HttpStatus.CONFLICT, "스크랩하지 않은 게시글입니다."),
+    NOT_SCRAP_TYPE(HttpStatus.BAD_REQUEST, "스크랩 가능한 객체가 아닙니다."),
 
     // Like
     LIKE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 좋아요한 게시글입니다."),

--- a/src/main/java/com/kakaotech/ott/ott/post/application/serviceImpl/PostServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/post/application/serviceImpl/PostServiceImpl.java
@@ -29,8 +29,11 @@ import com.kakaotech.ott.ott.scrap.domain.repository.ScrapRepository;
 import com.kakaotech.ott.ott.user.domain.model.User;
 import com.kakaotech.ott.ott.user.domain.repository.UserAuthRepository;
 import com.kakaotech.ott.ott.util.KstDateTime;
+import com.kakaotech.ott.ott.util.scheduler.LikeRedisKey;
+import com.kakaotech.ott.ott.util.scheduler.ScrapRedisKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -55,6 +58,7 @@ public class PostServiceImpl implements PostService {
     private final CommentRepository commentRepository;
     private final PointHistoryRepository pointHistoryRepository;
     private final PostQueryRepository postQueryRepository;
+    private final RedisTemplate<String, String> redisTemplate;
 
 
     @Value("${cloud.aws.s3.base-url}")
@@ -100,7 +104,6 @@ public class PostServiceImpl implements PostService {
 
         PointHistory afterPointHistory = PointHistory.createPointHistory(user.getId(), 200, beforePointHistory.getBalanceAfter() + 200, PointActionType.EARN, PointActionReason.POST_CREATE);
         pointHistoryRepository.save(afterPointHistory, user);
-        // user.updatePoint(200); TODO: PointHistory로 변경
         userAuthRepository.save(user);
 
         Post savedPost = postRepository.save(post);
@@ -118,59 +121,6 @@ public class PostServiceImpl implements PostService {
 
         return new PostCreateResponseDto(savedPost.getId());
     }
-
-//    @Override
-//    @Transactional(readOnly = true)
-//    public PostAllResponseDto getAllPost(Long userId, String category, String sort, int size, Long lastPostId,
-//                                         Integer lastLikeCount, Long lastViewCount, Double lastWeightCount) {
-//        List<Post> posts = postRepository.findAllByCursor(size, lastPostId, lastLikeCount, lastViewCount, lastWeightCount, category, sort);
-//
-//        List<PostAllResponseDto.Posts> dtoList = posts.stream()
-//                .map(post -> {
-//                    User author = userAuthRepository.findById(post.getUserId());
-//
-//                    boolean liked = likeRepository.existsByUserIdAndPostId(userId, post.getId());
-//                    boolean scrapped = (userId != null) && scrapRepository.existsByUserIdAndTypeAndPostId(userId, ScrapType.POST, post.getId());
-//                    int commentCount = commentRepository.findByPostId(post.getId());
-//                    Long likeCount = likeRepository.findByPostId(post.getId());
-//
-//                    String thumbnailImage = switch (post.getType()) {
-//                        case AI -> aiImageRepository.findByPostId(post.getId()).getAfterImagePath();
-//                        case FREE -> post.getImages().isEmpty() ? "" : post.getImages().get(0).getImageUuid();
-//                    };
-//
-//                    boolean isActive = userAuthRepository.findById(post.getUserId()).isActive();
-//
-//                    return new PostAllResponseDto.Posts(
-//                            post.getId(),
-//                            post.getTitle(),
-//                            new PostAllResponseDto.PostAuthorResponseDto(isActive
-//                                    ? author.getNicknameCommunity()
-//                                    : "알 수 없음",
-//                                    isActive
-//                                    ? author.getImagePath()
-//                                    : basicProfile),
-//                            thumbnailImage,
-//                            likeCount,
-//                            commentCount,
-//                            post.getViewCount(),
-//                            post.getWeight(),
-//                            new KstDateTime(post.getCreatedAt()),
-//                            liked,
-//                            scrapped
-//                    );
-//                })
-//                .toList();
-//
-//
-//        boolean hasNext = dtoList.size() == size;
-//        Long nextLastId = hasNext ? dtoList.get(dtoList.size() - 1).getPostId() : null;
-//        Long nextLastLikeCount = hasNext ? dtoList.get(dtoList.size() - 1).getLikeCount() : null;
-//        Long nextLastViewCount = hasNext ? dtoList.get(dtoList.size() - 1).getViewCount() : null;
-//        Double nextLastWeightCount = hasNext ? dtoList.get(dtoList.size() - 1).getWeightCount() : null;
-//
-//        return new PostAllResponseDto(dtoList, new PostAllResponseDto.Pagination(size, nextLastId, nextLastLikeCount, nextLastViewCount, nextLastWeightCount, hasNext));
-//    }
 
     @Override
     @Transactional(readOnly = true)
@@ -190,8 +140,10 @@ public class PostServiceImpl implements PostService {
         User user = userAuthRepository.findById(post.getUserId());
 
         boolean isOwner = post.getUserId().equals(userId);
-        boolean liked = likeRepository.existsByUserIdAndPostId(userId, post.getId());
-        boolean scrapped = (userId != null) && scrapRepository.existsByUserIdAndTypeAndPostId(userId, ScrapType.POST, post.getId());
+
+        boolean liked = likeCheck(userId, postId);
+
+        boolean scrapped = scrapCheck(userId, postId);
 
         List<?> imageUrls = imageLoaderManager.loadImages(post.getType(), postId);
 
@@ -220,6 +172,48 @@ public class PostServiceImpl implements PostService {
                 imageUrls,
                 new KstDateTime(post.getCreatedAt())
         );
+    }
+
+    private boolean likeCheck(Long userId, Long postId) {
+        String key = LikeRedisKey.setLikeKey(postId);
+        String member = String.valueOf(userId);
+
+        Boolean inRedis = redisTemplate.opsForSet().isMember(key, member);
+
+        if (Boolean.TRUE.equals(inRedis)) {
+            return true;
+        }
+        if (Boolean.FALSE.equals(inRedis)) {
+            return false;
+        }
+
+        boolean inDb = likeRepository.existsByUserIdAndPostId(userId, postId);
+        if (inDb) {
+            redisTemplate.opsForSet().add(key, member);
+        }
+
+        return inDb;
+    }
+
+    private boolean scrapCheck(Long userId, Long targetId) {
+        String key = ScrapRedisKey.postSetKey(targetId);
+        String member = String.valueOf(userId);
+
+        Boolean inRedis = redisTemplate.opsForSet().isMember(key, member);
+
+        if (Boolean.TRUE.equals(inRedis)) {
+            return true;
+        }
+        if (Boolean.FALSE.equals(inRedis)) {
+            return false;
+        }
+
+        boolean inDb = scrapRepository.existsByUserIdAndTypeAndPostId(userId, ScrapType.POST, targetId);
+        if (inDb) {
+            redisTemplate.opsForSet().add(key, member);
+        }
+
+        return inDb;
     }
 
     @Override

--- a/src/main/java/com/kakaotech/ott/ott/scrap/application/service/ScrapService.java
+++ b/src/main/java/com/kakaotech/ott/ott/scrap/application/service/ScrapService.java
@@ -4,7 +4,6 @@ import com.kakaotech.ott.ott.scrap.presentation.dto.request.ScrapRequestDto;
 
 public interface ScrapService {
 
-    void likeScrap(Long userId, ScrapRequestDto scrapRequestDto);
+    void toggleScrap(Long userId, ScrapRequestDto scrapRequestDto);
 
-    void unlikeScrap(Long userId, ScrapRequestDto scrapRequestDto);
 }

--- a/src/main/java/com/kakaotech/ott/ott/scrap/domain/model/Scrap.java
+++ b/src/main/java/com/kakaotech/ott/ott/scrap/domain/model/Scrap.java
@@ -15,13 +15,16 @@ public class Scrap {
     private ScrapType type;
     private Long targetId;
     private Boolean isActive;
+    private String lastEventId;
     private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
-    public static Scrap createScrap(Long userId, ScrapType type, Long targetId) {
+    public static Scrap createScrap(Long userId, ScrapType type, Long targetId, String lastEventId) {
         return Scrap.builder()
                 .userId(userId)
                 .type(type)
                 .targetId(targetId)
+                .lastEventId(lastEventId)
                 .isActive(true) // 기본 활성화
                 .build();
     }

--- a/src/main/java/com/kakaotech/ott/ott/scrap/domain/repository/ScrapJpaRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/scrap/domain/repository/ScrapJpaRepository.java
@@ -13,7 +13,15 @@ import java.util.List;
 
 public interface ScrapJpaRepository extends JpaRepository<ScrapEntity, Long> {
 
-    boolean existsByUserEntityIdAndTypeAndTargetId(Long userId, ScrapType type, Long targetId);
+    @Query("""
+    SELECT CASE WHEN COUNT(s) > 0 THEN true ELSE false END
+    FROM ScrapEntity s
+    WHERE s.userEntity.id = :userId
+      AND s.type = :type
+      AND s.targetId = :targetId
+      AND s.isActive = true
+""")
+    boolean existsActiveByUserEntityIdAndTypeAndTargetId(Long userId, ScrapType type, Long targetId);
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM ScrapEntity s WHERE s.userEntity.id = :userId AND s.targetId = :postId")

--- a/src/main/java/com/kakaotech/ott/ott/scrap/domain/repository/ScrapRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/scrap/domain/repository/ScrapRepository.java
@@ -24,4 +24,7 @@ public interface ScrapRepository {
     int findByPostId(Long postId, ScrapType type);
 
     Slice<Scrap> findUserScrap(Long userId, Long cursorId, int size);
+
+    void bulkInsertOrReactivateWithBatch(List<Scrap> scraps, int batchSize);
+    void bulkDeactivateWithBatch(List<Scrap> scraps, int batchSize);
 }

--- a/src/main/java/com/kakaotech/ott/ott/scrap/infrastructure/entity/ScrapEntity.java
+++ b/src/main/java/com/kakaotech/ott/ott/scrap/infrastructure/entity/ScrapEntity.java
@@ -3,6 +3,7 @@ package com.kakaotech.ott.ott.scrap.infrastructure.entity;
 import com.kakaotech.ott.ott.scrap.domain.model.Scrap;
 import com.kakaotech.ott.ott.scrap.domain.model.ScrapType;
 import com.kakaotech.ott.ott.user.infrastructure.entity.UserEntity;
+import com.kakaotech.ott.ott.util.AuditEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -17,7 +18,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class ScrapEntity {
+public class ScrapEntity extends AuditEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,9 +38,8 @@ public class ScrapEntity {
     @Column(name = "is_active", nullable = false)
     private Boolean isActive;
 
-    @CreatedDate
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    @Column(name = "last_event_id", nullable = false, length = 32)
+    private String lastEventId;
 
     public Scrap toDomain() {
         return Scrap.builder()
@@ -48,7 +48,9 @@ public class ScrapEntity {
                 .type(this.type)
                 .targetId(this.targetId)
                 .isActive(this.isActive)
-                .createdAt(this.createdAt)
+                .lastEventId(this.lastEventId)
+                .createdAt(this.getCreatedAt())
+                .updatedAt(this.getUpdatedAt())
                 .build();
     }
 
@@ -59,7 +61,7 @@ public class ScrapEntity {
                 .type(scrap.getType())
                 .targetId(scrap.getTargetId())
                 .isActive(scrap.getIsActive())
-                .createdAt(scrap.getCreatedAt())
+                .lastEventId(scrap.getLastEventId())
                 .build();
     }
 }

--- a/src/main/java/com/kakaotech/ott/ott/scrap/infrastructure/repositoryImpl/ScrapRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/scrap/infrastructure/repositoryImpl/ScrapRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.kakaotech.ott.ott.scrap.infrastructure.repositoryImpl;
 
+import com.kakaotech.ott.ott.like.domain.model.Like;
 import com.kakaotech.ott.ott.scrap.domain.model.Scrap;
 import com.kakaotech.ott.ott.scrap.domain.model.ScrapType;
 import com.kakaotech.ott.ott.scrap.domain.repository.ScrapJpaRepository;
@@ -7,6 +8,7 @@ import com.kakaotech.ott.ott.scrap.domain.repository.ScrapRepository;
 import com.kakaotech.ott.ott.scrap.infrastructure.entity.ScrapEntity;
 import com.kakaotech.ott.ott.user.infrastructure.entity.UserEntity;
 import com.kakaotech.ott.ott.user.domain.repository.UserJpaRepository;
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -24,6 +26,7 @@ public class ScrapRepositoryImpl implements ScrapRepository {
 
     private final ScrapJpaRepository scrapJpaRepository;
     private final UserJpaRepository userJpaRepository;
+    private final EntityManager em;
 
     @Override
     @Transactional
@@ -47,7 +50,7 @@ public class ScrapRepositoryImpl implements ScrapRepository {
     @Override
     @Transactional(readOnly = true)
     public boolean existsByUserIdAndTypeAndPostId(Long userId, ScrapType scrapType, Long postId) {
-        return scrapJpaRepository.existsByUserEntityIdAndTypeAndTargetId(userId, scrapType, postId);
+        return scrapJpaRepository.existsActiveByUserEntityIdAndTypeAndTargetId(userId, scrapType, postId);
     }
 
     @Override
@@ -71,6 +74,88 @@ public class ScrapRepositoryImpl implements ScrapRepository {
         Slice<ScrapEntity> slice = scrapJpaRepository.findUserAllScraps(userId, cursorId, PageRequest.of(0, size));
 
         return slice.map(ScrapEntity::toDomain);
+    }
+
+    @Override
+    public void bulkInsertOrReactivateWithBatch(List<Scrap> scraps, int batchSize) {
+        if (scraps == null || scraps.isEmpty()) return;
+        if (batchSize <= 0) batchSize = 500;
+
+        for (int i = 0; i < scraps.size(); i += batchSize) {
+            int end = Math.min(i + batchSize, scraps.size());
+            List<Scrap> subList = scraps.subList(i, end);
+            bulkInsertOrReactivate(subList);
+        }
+    }
+
+    private void bulkInsertOrReactivate(List<Scrap> scraps) {
+        if (scraps.isEmpty()) return;
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("""
+        INSERT INTO scraps (user_id, type, target_id, is_active, created_at)
+        VALUES
+    """);
+
+        for (int i = 0; i < scraps.size(); i++) {
+            Scrap scrap = scraps.get(i);
+            sb.append("(")
+                    .append(scrap.getUserId()).append(", ")
+                    .append("'").append(scrap.getType()).append("', ")
+                    .append(scrap.getTargetId()).append(", ")
+                    .append(true).append(", ")
+                    .append("now()")
+                    .append(")");
+            if (i < scraps.size() - 1) {
+                sb.append(", ");
+            }
+        }
+
+        sb.append("""
+        ON DUPLICATE KEY UPDATE
+        is_active = true
+    """);
+
+        em.createNativeQuery(sb.toString()).executeUpdate();
+    }
+
+
+    @Override
+    public void bulkDeactivateWithBatch(List<Scrap> scraps, int batchSize) {
+        if (scraps == null || scraps.isEmpty()) return;
+        if (batchSize <= 0) batchSize = 500;
+
+        for (int i = 0; i < scraps.size(); i += batchSize) {
+            int end = Math.min(i + batchSize, scraps.size());
+            List<Scrap> subList = scraps.subList(i, end);
+            bulkDeactivate(subList);
+        }
+    }
+
+    private void bulkDeactivate(List<Scrap> scraps) {
+        if (scraps.isEmpty()) return;
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("""
+        UPDATE scraps
+        SET is_active = false
+        WHERE (user_id, type, target_id) IN (
+    """);
+
+        for (int i = 0; i < scraps.size(); i++) {
+            Scrap scrap = scraps.get(i);
+            sb.append("(")
+                    .append(scrap.getUserId()).append(", ")
+                    .append("'").append(scrap.getType()).append("', ")
+                    .append(scrap.getTargetId()).append(")");
+            if (i < scraps.size() - 1) {
+                sb.append(", ");
+            }
+        }
+
+        sb.append(")");
+
+        em.createNativeQuery(sb.toString()).executeUpdate();
     }
 
 }

--- a/src/main/java/com/kakaotech/ott/ott/scrap/infrastructure/sycn/ScrapEvent.java
+++ b/src/main/java/com/kakaotech/ott/ott/scrap/infrastructure/sycn/ScrapEvent.java
@@ -1,0 +1,16 @@
+package com.kakaotech.ott.ott.scrap.infrastructure.sycn;
+
+import com.kakaotech.ott.ott.scrap.domain.model.ScrapType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ScrapEvent {
+    private Long userId;
+    private Long targetId;
+    private ScrapType type;
+    private String action;
+}

--- a/src/main/java/com/kakaotech/ott/ott/scrap/infrastructure/sycn/ScrapEventPublisher.java
+++ b/src/main/java/com/kakaotech/ott/ott/scrap/infrastructure/sycn/ScrapEventPublisher.java
@@ -1,0 +1,32 @@
+package com.kakaotech.ott.ott.scrap.infrastructure.sycn;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.stream.ObjectRecord;
+import org.springframework.data.redis.connection.stream.StreamRecords;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ScrapEventPublisher {
+
+    private static final String SCRAP_STREAM_KEY_POST = "scrap:stream:post:events";
+    private static final String SCRAP_STREAM_KEY_PRODUCT = "scrap:stream:product:events";
+    private static final String SCRAP_STREAM_KEY_SERVICE_PRODUCT = "scrap:stream:service-product:events";
+
+    private final RedisTemplate<String, ScrapEvent> redisTemplate;
+
+    public void publish(ScrapEvent event) {
+        String streamKey = switch (event.getType()) {
+            case POST               -> SCRAP_STREAM_KEY_POST;
+            case PRODUCT            -> SCRAP_STREAM_KEY_PRODUCT;
+            case SERVICE_PRODUCT    -> SCRAP_STREAM_KEY_SERVICE_PRODUCT;
+        };
+
+        ObjectRecord<String, ScrapEvent> record = StreamRecords
+                .objectBacked(event)
+                .withStreamKey(streamKey);
+
+        redisTemplate.opsForStream().add(record);
+    }
+}

--- a/src/main/java/com/kakaotech/ott/ott/scrap/infrastructure/sycn/ScrapSyncService.java
+++ b/src/main/java/com/kakaotech/ott/ott/scrap/infrastructure/sycn/ScrapSyncService.java
@@ -1,0 +1,8 @@
+package com.kakaotech.ott.ott.scrap.infrastructure.sycn;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ScrapSyncService {
+    void syncBatchWithVersion(List<Object[]> params, Map<String, Long> deltas);
+}

--- a/src/main/java/com/kakaotech/ott/ott/scrap/infrastructure/sycn/ScrapSyncServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/scrap/infrastructure/sycn/ScrapSyncServiceImpl.java
@@ -1,0 +1,44 @@
+package com.kakaotech.ott.ott.scrap.infrastructure.sycn;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ScrapSyncServiceImpl implements ScrapSyncService{
+
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    @Override
+    public void syncBatchWithVersion(List<Object[]> params, Map<String, Long> deltas) {
+        String sql = """
+                INSERT INTO scraps (user_id, type, target_id, is_active, last_event_id)
+                VALUES (:userId, :type, :targetId, :scrapped, :eventId)
+                ON DUPLICATE KEY UPDATE
+                    is_active = IF(last_event_id < VALUES(last_event_id),
+                                    VALUES(is_active),
+                                    is_active),
+                    last_event_id = IF(last_event_id < VALUES(last_event_id),
+                                    VALUES(last_event_id),
+                                    last_event_id)
+                """;
+
+        SqlParameterSource[] batch = params.stream()
+                .map(p -> new MapSqlParameterSource()
+                        .addValue("userId", p[0])
+                        .addValue("type", p[1])
+                        .addValue("targetId", p[2])
+                        .addValue("scrapped", p[3])
+                        .addValue("eventId", p[4]))
+                .toArray(SqlParameterSource[]::new);
+
+        namedParameterJdbcTemplate.batchUpdate(sql, batch);
+    }
+}
+

--- a/src/main/java/com/kakaotech/ott/ott/scrap/presentation/controller/ScrapController.java
+++ b/src/main/java/com/kakaotech/ott/ott/scrap/presentation/controller/ScrapController.java
@@ -19,24 +19,13 @@ public class ScrapController {
     private final ScrapService scrapService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse> activeScrap(@AuthenticationPrincipal UserPrincipal userPrincipal,
-                                                  @RequestBody @Valid ScrapRequestDto scrapRequestDto) {
+    public ResponseEntity<ApiResponse> toggleScrap(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                                   @RequestBody @Valid ScrapRequestDto scrapRequestDto) {
 
         Long userId = userPrincipal.getId();
 
-        scrapService.likeScrap(userId, scrapRequestDto);
+        scrapService.toggleScrap(userId, scrapRequestDto);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("스크랩 완료", null));
-    }
-
-    @DeleteMapping
-    public ResponseEntity<Void> deactiveScrap(@AuthenticationPrincipal UserPrincipal userPrincipal,
-                                                    @RequestBody @Valid ScrapRequestDto scrapRequestDto) {
-
-        Long userId = userPrincipal.getId();
-
-        scrapService.unlikeScrap(userId, scrapRequestDto);
-
-        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/kakaotech/ott/ott/util/scheduler/ScrapPendingMessageRetryScheduler.java
+++ b/src/main/java/com/kakaotech/ott/ott/util/scheduler/ScrapPendingMessageRetryScheduler.java
@@ -1,0 +1,106 @@
+package com.kakaotech.ott.ott.util.scheduler;
+
+import com.kakaotech.ott.ott.global.config.StreamConfig;
+import com.kakaotech.ott.ott.scrap.domain.model.ScrapType;
+import com.kakaotech.ott.ott.scrap.infrastructure.sycn.ScrapSyncService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessage;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@Slf4j
+public class ScrapPendingMessageRetryScheduler {
+
+    private final StringRedisTemplate streamStringRedisTemplate;
+    private final ScrapSyncService scrapSyncService;
+    private final List<StreamConfig> configs;
+
+    public ScrapPendingMessageRetryScheduler(
+            @Qualifier("streamStringRedisTemplate") StringRedisTemplate streamStringRedisTemplate,
+            ScrapSyncService scrapSyncService,
+            List<StreamConfig> configs
+    ) {
+        this.streamStringRedisTemplate = streamStringRedisTemplate;
+        this.scrapSyncService = scrapSyncService;
+        this.configs = configs;
+    }
+
+    @Scheduled(fixedDelay = 60_000, initialDelay = 30_000)
+    public void retryAllPending() {
+        for (StreamConfig cfg : configs){
+            retryPendingFor(cfg);
+        }
+
+    }
+
+    private void retryPendingFor(StreamConfig cfg) {
+        var pendingPost = streamStringRedisTemplate.opsForStream()
+                .pending(cfg.getStreamKey(), cfg.getGroup(), Range.unbounded(), 100);
+
+        for (PendingMessage msg : pendingPost) {
+            if (msg.getElapsedTimeSinceLastDelivery().toMillis() < 30_000)
+                continue;
+
+            @SuppressWarnings("unchecked")
+            List<MapRecord<String, String, String>> claimed =
+                    (List<MapRecord<String, String, String>>) (List<?>)
+                            streamStringRedisTemplate.opsForStream()
+                                    .claim(
+                                            cfg.getStreamKey(),
+                                            cfg.getGroup(),
+                                            cfg.getRetryConsumer(),
+                                            Duration.ofMillis(1),
+                                            msg.getId()
+                                    );
+
+            if (claimed == null || claimed.isEmpty()) {
+                continue;
+            }
+
+            List<Object[]> params = claimed.stream()
+                    .map(r -> {
+                        Map<String, String> v = r.getValue();
+                        long userId = Long.parseLong(v.get("userId"));
+                        String type = v.get("type");
+                        long targetId = Long.parseLong(v.get("targetId"));
+                        boolean scrap = "scrap".equals(v.get("action"));
+                        String eventId = r.getId().toString();
+                        return new Object[]{userId, type, targetId, scrap, eventId};
+                    })
+                    .collect(Collectors.toList());
+
+            Map<String, Long> deltas = claimed.stream()
+                    .collect(Collectors.groupingBy(
+                            r -> r.getValue().get("type")
+                                    + ":"
+                                    + r.getValue().get("targetId"),
+                            Collectors.summingLong(r ->
+                                    "scrap".equals(r.getValue().get("action")) ? 1L : -1L)
+                    ));
+
+            try {
+                scrapSyncService.syncBatchWithVersion(params, deltas);
+
+                RecordId[] ids = claimed.stream()
+                        .map(MapRecord::getId)
+                        .toArray(RecordId[]::new);
+                streamStringRedisTemplate.opsForStream().acknowledge(cfg.getStreamKey(), cfg.getGroup(), ids);
+                streamStringRedisTemplate.opsForStream().delete(cfg.getStreamKey(), ids);
+            } catch (Exception e) {
+                log.error("[PendingRetry - Scrap] 메시지 처리 실패: {}", msg.getId(), e);
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/kakaotech/ott/ott/util/scheduler/ScrapRedisKey.java
+++ b/src/main/java/com/kakaotech/ott/ott/util/scheduler/ScrapRedisKey.java
@@ -1,0 +1,20 @@
+package com.kakaotech.ott.ott.util.scheduler;
+
+public class ScrapRedisKey {
+        public static String postSetKey(Long postId) {
+            return "scrap:set:post:" + postId;
+        }
+
+        public static String productSetKey(Long productId) {
+            return "scrap:set:product:" + productId;
+        }
+
+        public static String serviceProductSetKey(Long spId) {
+            return "scrap:set:service_product:" + spId;
+        }
+
+        // Stream 용 키
+        public static final String SCRAP_STREAM_KEY_POST            = "scrap:stream:post:events";
+        public static final String SCRAP_STREAM_KEY_PRODUCT         = "scrap:stream:product:events";
+        public static final String SCRAP_STREAM_KEY_SERVICE_PRODUCT = "scrap:stream:service_product:events";
+}

--- a/src/main/resources/db/migration/V9__scraps_new_column.sql
+++ b/src/main/resources/db/migration/V9__scraps_new_column.sql
@@ -1,0 +1,16 @@
+ALTER TABLE `scraps`
+  MODIFY COLUMN `created_at` TIMESTAMP NOT NULL
+    DEFAULT CURRENT_TIMESTAMP,
+  ADD COLUMN    `last_event_id` VARCHAR(32) NOT NULL
+    DEFAULT '0',
+  ADD COLUMN    `updated_at` TIMESTAMP    NOT NULL
+    DEFAULT CURRENT_TIMESTAMP
+    ON UPDATE CURRENT_TIMESTAMP;
+
+UPDATE `scraps`
+SET
+  `last_event_id` = '0',
+  `updated_at`    = `created_at`;
+
+ALTER TABLE `scraps`
+  ALTER COLUMN `last_event_id` DROP DEFAULT;


### PR DESCRIPTION

## ✏️ PR 내용
### feat: Scrap 요청 및 취소 시 곧바로 DB 접근 방식 대신 Redis 방식 적용

### 설명
- 기존 스크랩 요청 및 취소 시 곧바로 DB 접근 방식 적용
- 요청 및 취소에 대한 API를 POST와 DELETE 메서드 방식으로 분리시켜 적용
- 수정 후 POST 하나의 API로 통합하여 toggle 방식 적용
- Redis Set에서 스크랩 상태를 파악하고 stream을 통해 DB로 비동기 처리
- 스크랩 종류에 따라 Stream 분리