### PR TITLE
feat: 게시글 목록 및 상세 페이지에 concept 추가 리턴

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/OttApplication.java
+++ b/src/main/java/com/kakaotech/ott/ott/OttApplication.java
@@ -4,10 +4,8 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-import java.util.TimeZone;
-
-@EnableScheduling
 @SpringBootApplication
+@EnableScheduling
 public class OttApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/kakaotech/ott/ott/post/application/component/PostDtoMapper.java
+++ b/src/main/java/com/kakaotech/ott/ott/post/application/component/PostDtoMapper.java
@@ -1,9 +1,9 @@
 package com.kakaotech.ott.ott.post.application.component;
 
+import com.kakaotech.ott.ott.aiImage.domain.model.AiImageConcept;
 import com.kakaotech.ott.ott.post.infrastructure.entity.PostEntity;
 import com.kakaotech.ott.ott.post.presentation.dto.response.PostAllResponseDto;
 import com.kakaotech.ott.ott.util.KstDateTime;
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,13 +11,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @RequiredArgsConstructor
 public class PostDtoMapper {
-    private final JPAQueryFactory queryFactory;
 
     @Transactional(readOnly = true)
-    public PostAllResponseDto.Posts toDto(PostEntity post, String thumbnail, boolean liked, boolean scrapped) {
+    public PostAllResponseDto.Posts toDto(PostEntity post, AiImageConcept concept, String thumbnail, boolean liked, boolean scrapped) {
         return new PostAllResponseDto.Posts(
                 post.getId(),
                 post.getTitle(),
+                concept,
                 new PostAllResponseDto.PostAuthorResponseDto(
                         post.getUserEntity().getNicknameCommunity(),
                         post.getUserEntity().getImagePath()

--- a/src/main/java/com/kakaotech/ott/ott/post/application/serviceImpl/PostServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/post/application/serviceImpl/PostServiceImpl.java
@@ -2,6 +2,7 @@ package com.kakaotech.ott.ott.post.application.serviceImpl;
 
 import com.kakaotech.ott.ott.aiImage.application.serviceImpl.S3Uploader;
 import com.kakaotech.ott.ott.aiImage.domain.model.AiImage;
+import com.kakaotech.ott.ott.aiImage.domain.model.AiImageConcept;
 import com.kakaotech.ott.ott.aiImage.domain.repository.AiImageRepository;
 import com.kakaotech.ott.ott.comment.domain.repository.CommentRepository;
 import com.kakaotech.ott.ott.global.exception.CustomException;
@@ -139,6 +140,8 @@ public class PostServiceImpl implements PostService {
 
         User user = userAuthRepository.findById(post.getUserId());
 
+        AiImageConcept concept = getConceptForPost(postId, post.getType());
+
         boolean isOwner = post.getUserId().equals(userId);
 
         boolean liked = likeCheck(userId, postId);
@@ -157,6 +160,7 @@ public class PostServiceImpl implements PostService {
                 post.getTitle(),
                 post.getContent(),
                 post.getType(),
+                concept,
                 new PostAuthorResponseDto(isActive
                         ? user.getNicknameCommunity()
                         : "알 수 없음",
@@ -172,6 +176,14 @@ public class PostServiceImpl implements PostService {
                 imageUrls,
                 new KstDateTime(post.getCreatedAt())
         );
+    }
+
+    private AiImageConcept getConceptForPost(Long postId, PostType postType) {
+        if (postType == PostType.FREE) {
+            return null;
+        }
+
+        return aiImageRepository.findByPostId(postId).getConcept();
     }
 
     private boolean likeCheck(Long userId, Long postId) {

--- a/src/main/java/com/kakaotech/ott/ott/post/presentation/controller/PostController.java
+++ b/src/main/java/com/kakaotech/ott/ott/post/presentation/controller/PostController.java
@@ -28,7 +28,7 @@ public class PostController {
     private final PostService postService;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<PostAllResponseDto>> getAllPostS(
+    public ResponseEntity<ApiResponse<PostAllResponseDto>> getAllPosts(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @RequestParam(required = false) String category,
             @RequestParam(required = false, defaultValue = "LATEST") String sort,

--- a/src/main/java/com/kakaotech/ott/ott/post/presentation/dto/response/PostAllResponseDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/post/presentation/dto/response/PostAllResponseDto.java
@@ -1,6 +1,7 @@
 package com.kakaotech.ott.ott.post.presentation.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kakaotech.ott.ott.aiImage.domain.model.AiImageConcept;
 import com.kakaotech.ott.ott.util.KstDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -18,6 +19,7 @@ public class PostAllResponseDto {
     public static class Posts {
         private final Long postId;
         private final String title;
+        private final AiImageConcept concept;
         private final PostAuthorResponseDto author;
         private final String thumbnailUrl;
         private final Long likeCount;

--- a/src/main/java/com/kakaotech/ott/ott/post/presentation/dto/response/PostGetResponseDto.java
+++ b/src/main/java/com/kakaotech/ott/ott/post/presentation/dto/response/PostGetResponseDto.java
@@ -1,7 +1,7 @@
 package com.kakaotech.ott.ott.post.presentation.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kakaotech.ott.ott.aiImage.domain.model.AiImageConcept;
 import com.kakaotech.ott.ott.post.domain.model.PostType;
 import com.kakaotech.ott.ott.util.KstDateTime;
 import lombok.AllArgsConstructor;
@@ -9,10 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Getter
@@ -28,6 +24,8 @@ public class PostGetResponseDto {
     private String content;
 
     private PostType type;
+
+    private AiImageConcept concept;
 
     private PostAuthorResponseDto author;
 

--- a/src/main/java/com/kakaotech/ott/ott/post/presentation/dto/response/ThumbnailAndConceptMap.java
+++ b/src/main/java/com/kakaotech/ott/ott/post/presentation/dto/response/ThumbnailAndConceptMap.java
@@ -1,0 +1,23 @@
+package com.kakaotech.ott.ott.post.presentation.dto.response;
+
+import com.kakaotech.ott.ott.aiImage.domain.model.AiImageConcept;
+
+import java.util.Map;
+
+public class ThumbnailAndConceptMap {
+    private Map<Long, String> thumbnailMap;
+    private Map<Long, AiImageConcept> conceptMap;
+
+    public ThumbnailAndConceptMap(Map<Long, String> thumbnailMap, Map<Long, AiImageConcept> conceptMap) {
+        this.thumbnailMap = thumbnailMap;
+        this.conceptMap = conceptMap;
+    }
+
+    public Map<Long, String> getThumbnailMap() {
+        return thumbnailMap;
+    }
+
+    public Map<Long, AiImageConcept> getConceptMap() {
+        return conceptMap;
+    }
+}


### PR DESCRIPTION
## ✏️ PR 내용
### feat: 게시글 목록 및 상세 페이지에 concept 추가 리턴

### 설명
- 게시글에 대한 이미지의 concept 추가 제공
- 자유 게시판은 자유료 표기, AI는 데스크 생성 선택지에 맞게 표기