### PR TITLE
feat: 이미지 생성 토큰 유효성 검사 로직 변경

### DIFF
--- a/src/main/java/com/kakaotech/ott/ott/aiImage/application/service/AiImageService.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/application/service/AiImageService.java
@@ -11,6 +11,8 @@ import java.io.IOException;
 
 public interface AiImageService {
 
+    void checkQuota(Long userId);
+
     AiImageSaveResponseDto handleImageValidation(MultipartFile image, AiImageConcept concept, Long userId) throws IOException;
 
     AiImage insertAiImage(AiImageAndProductRequestDto aiImageAndProductRequestDto);

--- a/src/main/java/com/kakaotech/ott/ott/aiImage/domain/repository/AiImageJpaRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/domain/repository/AiImageJpaRepository.java
@@ -1,5 +1,6 @@
 package com.kakaotech.ott.ott.aiImage.domain.repository;
 
+import com.kakaotech.ott.ott.aiImage.domain.model.AiImageState;
 import com.kakaotech.ott.ott.aiImage.infrastructure.entity.AiImageEntity;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -13,6 +14,9 @@ import java.util.Optional;
 public interface AiImageJpaRepository extends JpaRepository<AiImageEntity, Long> {
 
     Optional<AiImageEntity> findByBeforeImagePath(String beforeImagePath);
+
+    @Query("SELECT COUNT(a) FROM AiImageEntity a WHERE a.userEntity.id = :userId AND a.state IN :states AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE")
+    int countByUserEntity_IdAndStateIn(Long userId, List<AiImageState> states);
 
     @Query("""
         SELECT ai 

--- a/src/main/java/com/kakaotech/ott/ott/aiImage/domain/repository/AiImageRepository.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/domain/repository/AiImageRepository.java
@@ -1,6 +1,7 @@
 package com.kakaotech.ott.ott.aiImage.domain.repository;
 
 import com.kakaotech.ott.ott.aiImage.domain.model.AiImage;
+import com.kakaotech.ott.ott.aiImage.domain.model.AiImageState;
 import com.kakaotech.ott.ott.aiImage.infrastructure.entity.AiImageEntity;
 import org.springframework.data.domain.Slice;
 
@@ -27,4 +28,6 @@ public interface AiImageRepository {
     Map<Long, AiImage> findByPostIds(List<Long> postIds);
 
     AiImage findByPostId(Long postId);
+
+    int countUserIdAndStateIn(Long userId);
 }

--- a/src/main/java/com/kakaotech/ott/ott/aiImage/infrastructure/repositoryImpl/AiImageRepositoryImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/infrastructure/repositoryImpl/AiImageRepositoryImpl.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -140,6 +141,13 @@ public class AiImageRepositoryImpl implements AiImageRepository {
         return aiImageJpaRepository.findByPostId(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.AIIMAGE_NOT_FOUND))
                 .toDomain();
+    }
+
+    @Override
+    public int countUserIdAndStateIn(Long userId) {
+        List<AiImageState> states = Arrays.asList(AiImageState.SUCCESS, AiImageState.PENDING);
+
+        return aiImageJpaRepository.countByUserEntity_IdAndStateIn(userId, states);
     }
 
 }

--- a/src/main/java/com/kakaotech/ott/ott/aiImage/presentation/controller/AiImageController.java
+++ b/src/main/java/com/kakaotech/ott/ott/aiImage/presentation/controller/AiImageController.java
@@ -54,7 +54,9 @@ public class AiImageController {
 
         Long userId = userPrincipal.getId();
 
-        userAuthService.checkQuota(userId);
+        //userAuthService.checkQuota(userId);
+
+        aiImageService.checkQuota(userId);
 
         MultipartFile image = requestDto.getBeforeImagePath();
 

--- a/src/main/java/com/kakaotech/ott/ott/user/application/serviceImpl/UserAuthServiceImpl.java
+++ b/src/main/java/com/kakaotech/ott/ott/user/application/serviceImpl/UserAuthServiceImpl.java
@@ -1,6 +1,6 @@
 package com.kakaotech.ott.ott.user.application.serviceImpl;
 
-import com.kakaotech.ott.ott.aiImage.domain.model.ImageGenerationHistory;
+import com.kakaotech.ott.ott.aiImage.domain.repository.AiImageRepository;
 import com.kakaotech.ott.ott.aiImage.domain.repository.ImageGenerationHistoryRepository;
 import com.kakaotech.ott.ott.aiImage.presentation.dto.response.CheckAiImageQuotaResponseDto;
 import com.kakaotech.ott.ott.global.exception.CustomException;
@@ -28,6 +28,7 @@ public class UserAuthServiceImpl implements UserAuthService {
     private final KakaoLogoutServiceImpl kakaoLogoutService;
     private final RefreshTokenRepository refreshTokenRepository;
     private final ImageGenerationHistoryRepository imageGenerationHistoryRepository;
+    private final AiImageRepository aiImageRepository;
 
     @Transactional(readOnly = true)
     public CheckAiImageQuotaResponseDto remainQuota(Long userId) {
@@ -35,14 +36,12 @@ public class UserAuthServiceImpl implements UserAuthService {
         if (userId == null)
             throw new CustomException(ErrorCode.AUTH_REQUIRED);
 
-        LocalDate today = LocalDate.now();
-
         // 1. 사용자가 존재하지 않으면 예외 발생 (404)
         User user = userAuthRepository.findById(userId);
 
-        int usedToken = imageGenerationHistoryRepository.checkGenerationTokenCount(user.getId(), today);
+        int usedToken = aiImageRepository.countUserIdAndStateIn(userId);
 
-        return new CheckAiImageQuotaResponseDto(3-usedToken);
+        return new CheckAiImageQuotaResponseDto(5-usedToken);
     }
 
     @Override


### PR DESCRIPTION

## ✏️ PR 내용
### feat: 이미지 생성 토큰 유효성 검사 로직 변경

### 설명
- 기존 이미지 생성 토큰 이미지 내역에서 조회
- 수정 후 이미지 테이블에서 성공 및 준비 데이터 모두 가져와 조회
- 이미지 준비중일 때 추가 생성 방지